### PR TITLE
Fix silent no-ops, ATC estimand, and matcher crashes

### DIFF
--- a/src/pymatchit/core.py
+++ b/src/pymatchit/core.py
@@ -119,23 +119,17 @@ class MatchIt:
         
         # 1. Estimate Distance / Propensity Scores
         if user_supplied_distance:
-            # User supplied pre-computed propensity scores
+            # User supplied a pre-computed distance vector. Like R MatchIt, the
+            # supplied values are used as-is for matching (no link transform):
+            # they need not be probabilities, so a logit would corrupt them.
             if isinstance(self.distance, np.ndarray):
                 ps = pd.Series(self.distance, index=self.data.index)
             else:
                 ps = self.distance.copy()
                 ps.index = self.data.index
-            
+
             self.propensity_scores = ps
-            
-            # Apply link transformation
-            if self.link in ['logit', 'linear.logit']:
-                from scipy.special import logit
-                eps = 1e-9
-                clipped = np.clip(ps, eps, 1 - eps)
-                self.distance_measure = pd.Series(logit(clipped), index=self.data.index)
-            else:
-                self.distance_measure = ps.copy()
+            self.distance_measure = ps.copy()
         else:
             should_estimate_ps = (distance_method != "mahalanobis") or (self.discard != "none")
             
@@ -185,32 +179,39 @@ class MatchIt:
             print(f"Note: {self.method.capitalize()} matching does not produce pairwise matches.")
             return pd.DataFrame()
 
+        # For ATC the focal group is the control group, so the keys of
+        # matched_indices are control units and the values are treated units
+        if self.estimand == "ATC":
+            key_col, val_col, val_prefix = 'control_index', 'treated_index', 'treated'
+        else:
+            key_col, val_col, val_prefix = 'treated_index', 'control_index', 'control'
+
         if format == "long":
             rows = []
             for t_idx, c_indices in self.matched_indices.items():
                 for c_idx in c_indices:
                     rows.append({
-                        'treated_index': t_idx,
-                        'control_index': c_idx
+                        key_col: t_idx,
+                        val_col: c_idx
                     })
             df = pd.DataFrame(rows)
-            
+
         elif format == "wide":
             rows = []
             for t_idx, c_indices in self.matched_indices.items():
-                row = {'treated_index': t_idx}
+                row = {key_col: t_idx}
                 for i, c_idx in enumerate(c_indices):
-                    row[f'control_{i+1}'] = c_idx
+                    row[f'{val_prefix}_{i+1}'] = c_idx
                 rows.append(row)
             df = pd.DataFrame(rows)
-            
+
         else:
             raise ValueError("Format must be 'long' or 'wide'.")
 
-        for col in df.columns:
-            if "index" in col or "control_" in col:
+        if pd.api.types.is_integer_dtype(self.data.index):
+            for col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce').astype("Int64")
-        
+
         return df
 
     def _validate_inputs(self, formula: str):
@@ -273,6 +274,31 @@ class MatchIt:
         if self.estimand not in valid_estimands:
             raise ValueError(f"Estimand must be one of {valid_estimands}, got '{self.estimand}'.")
 
+        # Pair-matching methods cannot target the ATE (same restriction as R MatchIt)
+        if self.estimand == "ATE" and self.method in ("nearest", "optimal", "genetic"):
+            raise ValueError(
+                f"estimand='ATE' is not compatible with method='{self.method}'. "
+                "Use 'full', 'subclass', 'exact', 'cem', or 'cardinality' instead."
+            )
+
+        if self.antiexact is not None and self.method not in ("nearest", "optimal"):
+            raise NotImplementedError(
+                f"antiexact is not supported for method='{self.method}'. "
+                "It is currently available for 'nearest' and 'optimal' matching."
+            )
+
+        if self.mahvars is not None:
+            if self.method not in ("nearest", "optimal", "full"):
+                raise NotImplementedError(
+                    f"mahvars is not supported for method='{self.method}'. "
+                    "It is currently available for 'nearest', 'optimal', and 'full' matching."
+                )
+            if isinstance(self.distance, str) and self.distance == "mahalanobis":
+                raise ValueError(
+                    "mahvars cannot be combined with distance='mahalanobis': mahvars already "
+                    "requests Mahalanobis matching, with the estimated distance kept for calipers."
+                )
+
         try:
             patsy.dmatrix(rhs, self.data, NA_action='raise', return_type='dataframe')
         except patsy.PatsyError as e:
@@ -322,23 +348,27 @@ class MatchIt:
 
     def _get_matcher(self) -> BaseMatcher:
         distance_method = self.distance if isinstance(self.distance, str) else "user"
-        is_mahalanobis = (distance_method == 'mahalanobis')
-        
+        # mahvars also requests Mahalanobis matching (on those variables only),
+        # with the estimated distance measure retained for calipers
+        is_mahalanobis = (distance_method == 'mahalanobis') or (self.mahvars is not None)
+
         if self.method == 'nearest':
             return NearestNeighborMatcher(
-                ratio=self.ratio, 
-                replace=self.replace, 
+                ratio=self.ratio,
+                replace=self.replace,
                 caliper=self.caliper,
                 m_order=self.m_order,
                 random_state=self.random_state,
-                mahalanobis=is_mahalanobis
+                mahalanobis=is_mahalanobis,
+                mahvars=self.mahvars
             )
         elif self.method == 'optimal':
             return OptimalMatcher(
                 ratio=self.ratio,
                 caliper=self.caliper,
                 random_state=self.random_state,
-                mahalanobis=is_mahalanobis
+                mahalanobis=is_mahalanobis,
+                mahvars=self.mahvars
             )
         elif self.method == 'exact':
             return ExactMatcher(
@@ -362,7 +392,8 @@ class MatchIt:
                 min_controls_per_subclass=self.min_controls_per_subclass,
                 max_controls_per_subclass=self.max_controls_per_subclass,
                 random_state=self.random_state,
-                mahalanobis=is_mahalanobis
+                mahalanobis=is_mahalanobis,
+                mahvars=self.mahvars
             )
         elif self.method == 'genetic':
             return GeneticMatcher(
@@ -408,8 +439,7 @@ class MatchIt:
             active_covs = X_data
             active_exact = self.data[self.exact] if self.exact else None
 
-        # Handle antiexact: filter out pairs where antiexact variables match
-        # This is done post-hoc for methods that support it
+        # Antiexact: matchers exclude pairs where any antiexact variable matches
         kwargs = {}
         if self.antiexact is not None:
             kwargs['antiexact'] = self.data[self.antiexact] if self._mask_kept is None else self.data.loc[self._mask_kept, self.antiexact]

--- a/src/pymatchit/distance.py
+++ b/src/pymatchit/distance.py
@@ -198,13 +198,14 @@ def _estimate_cbps(
         # Negative because we minimize
         return -log_lik + balance_loss
 
-    # Initialize with logistic regression coefficients
+    # Initialize with logistic regression coefficients. X_arr already contains
+    # the patsy intercept column, so no separate sklearn intercept is fit.
     try:
         from sklearn.linear_model import LogisticRegression as LR
-        init_model = LR(random_state=random_state, max_iter=1000, penalty=None, solver='lbfgs')
+        init_model = LR(random_state=random_state, max_iter=1000, penalty=None,
+                        solver='lbfgs', fit_intercept=False)
         init_model.fit(X_arr, y_arr)
-        beta_init = np.concatenate([init_model.intercept_, init_model.coef_.flatten()])
-        # Pad or trim to match X columns (patsy includes intercept)
+        beta_init = init_model.coef_.flatten()
         if len(beta_init) != p:
             beta_init = np.zeros(p)
     except Exception:

--- a/src/pymatchit/matchers.py
+++ b/src/pymatchit/matchers.py
@@ -9,6 +9,32 @@ from scipy.optimize import linear_sum_assignment
 from typing import Dict, List, Optional, Tuple, Any, Union
 from abc import ABC, abstractmethod
 
+
+def _resolve_mahalanobis_covariates(covariates: pd.DataFrame, mahvars: Optional[List[str]]) -> pd.DataFrame:
+    """
+    Selects the covariate columns used to compute the Mahalanobis distance.
+    If `mahvars` is given, maps each variable name to its design-matrix
+    column(s) (categorical variables appear as dummies like 'race[T.Hispanic]').
+    """
+    if not mahvars:
+        return covariates.select_dtypes(include=[np.number])
+    cols = []
+    for v in mahvars:
+        hits = [c for c in covariates.columns if c == v or c.startswith(f"{v}[")]
+        if not hits:
+            raise ValueError(f"mahvars variable '{v}' not found among model covariates.")
+        cols.extend(hits)
+    return covariates[cols].select_dtypes(include=[np.number])
+
+
+def _antiexact_violations(anti_t: np.ndarray, anti_c: np.ndarray) -> np.ndarray:
+    """Boolean (n_treated x n_control) matrix: True where any antiexact variable matches."""
+    violations = np.zeros((anti_t.shape[0], anti_c.shape[0]), dtype=bool)
+    for k in range(anti_t.shape[1]):
+        violations |= (anti_t[:, k:k+1] == anti_c[:, k:k+1].T)
+    return violations
+
+
 class BaseMatcher(ABC):
     """
     Abstract Base Class for all matching algorithms.
@@ -32,16 +58,21 @@ class BaseMatcher(ABC):
 
     def _build_result(self, matches: Dict[int, List[int]], all_indices: pd.Index) -> Tuple[Dict, pd.Series, pd.Series]:
         matched_treated = []
-        from collections import Counter
-        control_counts = Counter()
-        
+        # Each matched control contributes 1/k_i for every focal unit i it is
+        # matched to, where k_i is that unit's number of matches. This keeps
+        # weights correct when calipers leave some units with fewer than
+        # `ratio` matches, and reduces to use-counts for 1:1 with replacement.
+        control_weights: Dict[Any, float] = {}
+
         subclasses = pd.Series(pd.NA, index=all_indices)
         group_id = 1
 
         for t, c_list in matches.items():
             matched_treated.append(t)
-            control_counts.update(c_list)
-            
+            k = len(c_list)
+            for c in c_list:
+                control_weights[c] = control_weights.get(c, 0.0) + 1.0 / k
+
             subclasses.loc[t] = group_id
             for c in c_list:
                 if pd.isna(subclasses.loc[c]):
@@ -50,10 +81,10 @@ class BaseMatcher(ABC):
 
         weights = pd.Series(0.0, index=all_indices)
         weights.loc[matched_treated] = 1.0
-        
-        for c_idx, count in control_counts.items():
-            weights.loc[c_idx] = count 
-        
+
+        for c_idx, w in control_weights.items():
+            weights.loc[c_idx] = w
+
         return matches, weights, subclasses
 
 
@@ -62,44 +93,47 @@ class NearestNeighborMatcher(BaseMatcher):
     Implements Nearest Neighbor matching (Greedy) with Covariate-Specific Calipers.
     """
 
-    def __init__(self, ratio: int = 1, replace: bool = False, 
-                 caliper: Optional[Union[float, Dict[str, float]]] = None, 
-                 m_order: str = "largest", random_state: Optional[int] = None, mahalanobis: bool = False):
+    def __init__(self, ratio: int = 1, replace: bool = False,
+                 caliper: Optional[Union[float, Dict[str, float]]] = None,
+                 m_order: str = "largest", random_state: Optional[int] = None, mahalanobis: bool = False,
+                 mahvars: Optional[List[str]] = None):
         super().__init__(ratio=ratio, replace=replace, random_state=random_state)
         self.caliper = caliper
         self.m_order = m_order
         self.mahalanobis = mahalanobis
+        self.mahvars = mahvars
 
-    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, **kwargs):
+    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, antiexact=None, **kwargs):
+        if estimand == "ATC":
+            # The control group becomes the focal group: controls are matched
+            # to treated units (mirrors R MatchIt's focal-group switch).
+            treatment = 1 - treatment
         if exact is not None:
-            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact)
-        return self._match_global(treatment, distance_measure, covariates, estimand)
+            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact, antiexact)
+        return self._match_global(treatment, distance_measure, covariates, estimand, antiexact)
 
-    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df):
+    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df, antiexact=None):
         stratification_data = exact_df.copy()
         group_cols = list(exact_df.columns)
         grouped = stratification_data.groupby(group_cols)
         all_matches = {}
-        
+        # Caliper width is defined on the full sample's distance SD, not per stratum
+        dist_std = distance_measure.std() if distance_measure is not None else None
+
         for _, group_indices in grouped.groups.items():
             local_treat = treatment.loc[group_indices]
             if local_treat.sum() == 0 or (local_treat == 0).sum() == 0: continue
-            
+
             local_dist = distance_measure.loc[group_indices] if distance_measure is not None else None
             local_covs = covariates.loc[group_indices] if covariates is not None else None
-            
-            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand)
-            all_matches.update(matches)
-            
-        matches_dict, weights, subclasses = self._build_result(all_matches, treatment.index)
-        
-        if estimand == "ATT" and self.ratio > 1:
-            control_mask = (treatment == 0)
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-            
-        return matches_dict, weights, subclasses
+            local_anti = antiexact.loc[group_indices] if antiexact is not None else None
 
-    def _match_global(self, treatment, distance_measure, covariates, estimand):
+            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand, local_anti, dist_std=dist_std)
+            all_matches.update(matches)
+
+        return self._build_result(all_matches, treatment.index)
+
+    def _match_global(self, treatment, distance_measure, covariates, estimand, antiexact=None, dist_std=None):
         treated_mask = treatment == 1
         control_mask = treatment == 0
         treated_indices = treatment[treated_mask].index.to_numpy()
@@ -115,26 +149,29 @@ class NearestNeighborMatcher(BaseMatcher):
         elif self.caliper is not None:
             global_caliper = self.caliper
 
+        if dist_std is None and distance_measure is not None:
+            dist_std = distance_measure.std()
+
         if self.mahalanobis:
             if covariates is None: raise ValueError("Covariates required for Mahalanobis matching.")
             # For Mahalanobis, we only use numeric dummies, not the combined 'active_covs' frame
-            num_covs = covariates.select_dtypes(include=[np.number])
+            num_covs = _resolve_mahalanobis_covariates(covariates, self.mahvars)
             X_treated = num_covs[treated_mask].values
             X_control = num_covs[control_mask].values
-            
+
             try:
                 cov_matrix = num_covs.cov()
                 VI = pinv(cov_matrix.values)
             except:
                 VI = np.eye(num_covs.shape[1])
-                
+
             metric = 'mahalanobis'
             metric_params = {'VI': VI}
-            threshold = np.inf 
-            
+            threshold = np.inf
+
             if global_caliper is not None:
                 if distance_measure is None: raise ValueError("Caliper threshold requires 1D distance measure.")
-                threshold = global_caliper * distance_measure.std()
+                threshold = global_caliper * dist_std
         else:
             if distance_measure is None: raise ValueError("Distance measure required for nearest neighbor matching.")
             X_treated = distance_measure[treated_mask].values.reshape(-1, 1)
@@ -143,7 +180,7 @@ class NearestNeighborMatcher(BaseMatcher):
             metric_params = {}
             threshold = np.inf
             if global_caliper is not None:
-                threshold = global_caliper * distance_measure.std()
+                threshold = global_caliper * dist_std
 
         # Extract matrices for covariate-specific calipers
         covs_treated_caliper = None
@@ -163,66 +200,75 @@ class NearestNeighborMatcher(BaseMatcher):
             for idx, limit in enumerate(cov_calipers.values()):
                 cov_thresholds_mapped[idx] = limit
 
+        anti_treated = anti_control = None
+        if antiexact is not None:
+            anti_treated = antiexact.loc[treated_mask].values
+            anti_control = antiexact.loc[control_mask].values
+
         if self.replace:
-            matches = self._match_with_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped)
+            matches = self._match_with_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped, anti_treated, anti_control)
         else:
-            matches = self._match_without_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped)
+            matches = self._match_without_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped, anti_treated, anti_control)
 
-        matches_dict, weights, subclasses = self._build_result(matches, treatment.index)
-        if estimand == "ATT" and self.ratio > 1:
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-            
-        return matches_dict, weights, subclasses
+        return self._build_result(matches, treatment.index)
 
-    def _match_with_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds):
+    @staticmethod
+    def _violates_pair_constraints(i, local_pos, covs_treated, covs_control, cov_thresholds, anti_treated, anti_control):
+        if cov_thresholds:
+            for col_idx, limit in cov_thresholds.items():
+                if abs(covs_treated[i, col_idx] - covs_control[local_pos, col_idx]) > limit:
+                    return True
+        if anti_treated is not None:
+            if (anti_treated[i] == anti_control[local_pos]).any():
+                return True
+        return False
+
+    def _match_with_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds, anti_treated=None, anti_control=None):
         if len(X_control) == 0: return {}
-        
-        # If we have strict covariate calipers, we must fetch more neighbors because the closest PS match might violate the caliper
-        n_neighbors_to_fetch = len(X_control) if cov_thresholds else min(len(X_control), self.ratio)
-        
+
+        # With covariate calipers or antiexact constraints, the closest match
+        # may be invalid, so we must fetch all candidates
+        has_pair_constraints = bool(cov_thresholds) or anti_treated is not None
+        n_neighbors_to_fetch = len(X_control) if has_pair_constraints else min(len(X_control), self.ratio)
+
         nn = NearestNeighbors(n_neighbors=n_neighbors_to_fetch, metric=metric, metric_params=metric_params, algorithm='auto')
         nn.fit(X_control)
         dists, neighbor_indices = nn.kneighbors(X_treated)
-        
+
         matches = {}
         for i, t_idx in enumerate(treated_indices):
             valid_neighbors = []
             for j in range(dists.shape[1]):
                 dist = dists[i, j]
-                if dist > threshold: 
+                if dist > threshold:
                     break # Break early since distances are sorted
-                
+
                 local_pos = neighbor_indices[i, j]
-                
-                if cov_thresholds:
-                    violates_caliper = False
-                    for col_idx, limit in cov_thresholds.items():
-                        if abs(covs_treated[i, col_idx] - covs_control[local_pos, col_idx]) > limit:
-                            violates_caliper = True
-                            break
-                    if violates_caliper: continue
+
+                if self._violates_pair_constraints(i, local_pos, covs_treated, covs_control, cov_thresholds, anti_treated, anti_control):
+                    continue
 
                 valid_neighbors.append(control_indices[local_pos])
                 if len(valid_neighbors) >= self.ratio:
                     break
-                    
+
             if len(valid_neighbors) > 0:
                 matches[t_idx] = valid_neighbors
         return matches
 
-    def _match_without_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds):
+    def _match_without_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds, anti_treated=None, anti_control=None):
         if len(X_control) == 0: return {}
-        
+
         if self.m_order == "largest": sort_order = np.argsort(X_treated.flatten())[::-1] if X_treated.shape[1] == 1 else np.arange(len(X_treated))
         elif self.m_order == "smallest": sort_order = np.argsort(X_treated.flatten()) if X_treated.shape[1] == 1 else np.arange(len(X_treated))
-        elif self.m_order == "random": 
-            np.random.seed(self.random_state)
-            sort_order = np.random.permutation(len(X_treated))
+        elif self.m_order == "random":
+            rng = np.random.RandomState(self.random_state)
+            sort_order = rng.permutation(len(X_treated))
         else: sort_order = np.arange(len(X_treated))
 
         matches = {}
         available_mask = np.ones(len(X_control), dtype=bool)
-        
+
         n_neighbors_to_fetch = len(X_control)
         nn = NearestNeighbors(n_neighbors=n_neighbors_to_fetch, metric=metric, metric_params=metric_params)
         nn.fit(X_control)
@@ -231,24 +277,18 @@ class NearestNeighborMatcher(BaseMatcher):
         for i in sort_order:
             t_idx = treated_indices[i]
             found = []
-            
+
             for dist, local_pos in zip(dists[i], neighbors[i]):
                 if len(found) >= self.ratio: break
-                if dist > threshold: break 
+                if dist > threshold: break
                 if not available_mask[local_pos]: continue
-                
-                # Check Covariate-Specific Calipers
-                if cov_thresholds:
-                    violates_caliper = False
-                    for col_idx, limit in cov_thresholds.items():
-                        if abs(covs_treated[i, col_idx] - covs_control[local_pos, col_idx]) > limit:
-                            violates_caliper = True
-                            break
-                    if violates_caliper: continue
-                    
+
+                if self._violates_pair_constraints(i, local_pos, covs_treated, covs_control, cov_thresholds, anti_treated, anti_control):
+                    continue
+
                 found.append(control_indices[local_pos])
                 available_mask[local_pos] = False
-                    
+
             if found:
                 matches[t_idx] = found
         return matches
@@ -259,39 +299,43 @@ class OptimalMatcher(BaseMatcher):
     Implements Optimal Matching minimizing the total global distance.
     Supports Covariate-Specific Calipers.
     """
-    def __init__(self, ratio: int = 1, caliper: Optional[Union[float, Dict[str, float]]] = None, random_state: Optional[int] = None, mahalanobis: bool = False):
+    def __init__(self, ratio: int = 1, caliper: Optional[Union[float, Dict[str, float]]] = None, random_state: Optional[int] = None, mahalanobis: bool = False,
+                 mahvars: Optional[List[str]] = None):
         super().__init__(ratio=ratio, replace=False, random_state=random_state)
         self.caliper = caliper
         self.mahalanobis = mahalanobis
+        self.mahvars = mahvars
 
-    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, **kwargs):
+    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, antiexact=None, **kwargs):
+        if estimand == "ATC":
+            # The control group becomes the focal group (see NearestNeighborMatcher)
+            treatment = 1 - treatment
         if exact is not None:
-            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact)
-        return self._match_global(treatment, distance_measure, covariates, estimand)
+            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact, antiexact)
+        return self._match_global(treatment, distance_measure, covariates, estimand, antiexact)
 
-    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df):
+    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df, antiexact=None):
         stratification_data = exact_df.copy()
         group_cols = list(exact_df.columns)
         grouped = stratification_data.groupby(group_cols)
         all_matches = {}
-        
+        # Caliper width is defined on the full sample's distance SD, not per stratum
+        dist_std = distance_measure.std() if distance_measure is not None else None
+
         for _, group_indices in grouped.groups.items():
             local_treat = treatment.loc[group_indices]
             if local_treat.sum() == 0 or (local_treat == 0).sum() == 0: continue
-            
+
             local_dist = distance_measure.loc[group_indices] if distance_measure is not None else None
             local_covs = covariates.loc[group_indices] if covariates is not None else None
-            
-            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand)
-            all_matches.update(matches)
-            
-        matches_dict, weights, subclasses = self._build_result(all_matches, treatment.index)
-        if estimand == "ATT" and self.ratio > 1:
-            control_mask = (treatment == 0)
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-        return matches_dict, weights, subclasses
+            local_anti = antiexact.loc[group_indices] if antiexact is not None else None
 
-    def _match_global(self, treatment, distance_measure, covariates, estimand):
+            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand, local_anti, dist_std=dist_std)
+            all_matches.update(matches)
+
+        return self._build_result(all_matches, treatment.index)
+
+    def _match_global(self, treatment, distance_measure, covariates, estimand, antiexact=None, dist_std=None):
         treated_mask = treatment == 1
         control_mask = treatment == 0
         treated_indices = treatment[treated_mask].index.to_numpy()
@@ -326,9 +370,18 @@ class OptimalMatcher(BaseMatcher):
             covs_c_caliper = None
             cov_limits = None
 
+        if dist_std is None and distance_measure is not None:
+            dist_std = distance_measure.std()
+
+        # Pairs violating a caliper or antiexact constraint are marked forbidden.
+        # linear_sum_assignment cannot handle np.inf when no complete feasible
+        # assignment exists, so forbidden cells get a large finite penalty and
+        # forbidden pairs are dropped from the solution afterwards.
+        forbidden = np.zeros((n_treated, n_controls), dtype=bool)
+
         if self.mahalanobis:
             if covariates is None: raise ValueError("Covariates required for Mahalanobis matching.")
-            num_covs = covariates.select_dtypes(include=[np.number])
+            num_covs = _resolve_mahalanobis_covariates(covariates, self.mahvars)
             X_t = num_covs[treated_mask].values
             X_c = num_covs[control_mask].values
             try:
@@ -336,32 +389,47 @@ class OptimalMatcher(BaseMatcher):
             except:
                 VI = np.eye(num_covs.shape[1])
             dist_matrix = cdist(X_t, X_c, metric='mahalanobis', VI=VI)
-            
+
             if global_caliper is not None:
                 if distance_measure is None: raise ValueError("Caliper requires 1D distance measure.")
                 ps_t = distance_measure[treated_mask].values.reshape(-1, 1)
                 ps_c = distance_measure[control_mask].values.reshape(-1, 1)
                 ps_dist = cdist(ps_t, ps_c, metric='euclidean')
-                threshold = global_caliper * distance_measure.std()
-                dist_matrix[ps_dist > threshold] = np.inf
+                threshold = global_caliper * dist_std
+                forbidden |= ps_dist > threshold
         else:
             if distance_measure is None: raise ValueError("Distance measure required.")
             X_t = distance_measure[treated_mask].values.reshape(-1, 1)
             X_c = distance_measure[control_mask].values.reshape(-1, 1)
             dist_matrix = cdist(X_t, X_c, metric='euclidean')
-            
-            if global_caliper is not None:
-                threshold = global_caliper * distance_measure.std()
-                dist_matrix[dist_matrix > threshold] = np.inf
 
-        # Apply covariate-specific calipers directly to dist_matrix
+            if global_caliper is not None:
+                threshold = global_caliper * dist_std
+                forbidden |= dist_matrix > threshold
+
+        # Apply covariate-specific calipers
         if cov_limits is not None:
             for col_idx, limit in enumerate(cov_limits):
                 diffs = np.abs(covs_t_caliper[:, col_idx:col_idx+1] - covs_c_caliper[:, col_idx:col_idx+1].T)
-                dist_matrix[diffs > limit] = np.inf
+                forbidden |= diffs > limit
+
+        # Apply antiexact constraints
+        if antiexact is not None:
+            anti_t = antiexact.loc[treated_mask].values
+            anti_c = antiexact.loc[control_mask].values
+            forbidden |= _antiexact_violations(anti_t, anti_c)
+
+        if forbidden.any():
+            feasible_vals = dist_matrix[~forbidden]
+            max_feasible = feasible_vals.max() if feasible_vals.size > 0 else 1.0
+            n_assignable = min(n_treated * self.ratio, n_controls)
+            penalty = (abs(max_feasible) + 1.0) * (n_assignable + 1)
+            dist_matrix = dist_matrix.copy()
+            dist_matrix[forbidden] = penalty
 
         if self.ratio > 1:
             dist_matrix = np.repeat(dist_matrix, self.ratio, axis=0)
+            forbidden = np.repeat(forbidden, self.ratio, axis=0)
             expanded_treated_indices = np.repeat(treated_indices, self.ratio)
         else:
             expanded_treated_indices = treated_indices
@@ -370,18 +438,14 @@ class OptimalMatcher(BaseMatcher):
 
         matches = {}
         for r, c in zip(row_ind, col_ind):
-            if dist_matrix[r, c] == np.inf: continue
+            if forbidden[r, c]: continue
             t_idx = expanded_treated_indices[r]
             c_idx = control_indices[c]
-            
+
             if t_idx not in matches: matches[t_idx] = []
             matches[t_idx].append(c_idx)
 
-        matches_dict, weights, subclasses = self._build_result(matches, treatment.index)
-        if estimand == "ATT" and self.ratio > 1:
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-            
-        return matches_dict, weights, subclasses
+        return self._build_result(matches, treatment.index)
 
 
 class ExactMatcher(BaseMatcher):
@@ -419,6 +483,9 @@ class ExactMatcher(BaseMatcher):
                     n_total = n_treat + n_control
                     weights.loc[treated_in_group['__original_index__']] = n_total / n_treat
                     weights.loc[control_in_group['__original_index__']] = n_total / n_control
+                elif estimand == "ATC":
+                    weights.loc[control_in_group['__original_index__']] = 1.0
+                    weights.loc[treated_in_group['__original_index__']] = n_control / n_treat
 
         return matches, weights, subclasses
 
@@ -429,8 +496,15 @@ class SubclassMatcher(BaseMatcher):
 
     def match(self, treatment, distance_measure, estimand="ATT", **kwargs):
         if distance_measure is None: raise ValueError("Propensity Scores required for Subclassification.")
-        treated_scores = distance_measure[treatment == 1]
-        _, bins = pd.qcut(treated_scores, q=self.n_subclasses, retbins=True, duplicates='drop')
+        # Bin edges come from the focal group's score distribution (R MatchIt:
+        # treated for ATT, control for ATC, everyone for ATE)
+        if estimand == "ATC":
+            ref_scores = distance_measure[treatment == 0]
+        elif estimand == "ATE":
+            ref_scores = distance_measure
+        else:
+            ref_scores = distance_measure[treatment == 1]
+        _, bins = pd.qcut(ref_scores, q=self.n_subclasses, retbins=True, duplicates='drop')
         bins[0], bins[-1] = -np.inf, np.inf
         
         subclass_labels = pd.cut(distance_measure, bins=bins, labels=False, include_lowest=True)
@@ -453,6 +527,9 @@ class SubclassMatcher(BaseMatcher):
                 n_total = n_treated + n_control
                 weights.loc[(treatment == 1) & in_bin] = n_total / n_treated
                 weights.loc[(treatment == 0) & in_bin] = n_total / n_control
+            elif estimand == "ATC":
+                weights.loc[(treatment == 0) & in_bin] = 1.0
+                weights.loc[(treatment == 1) & in_bin] = n_control / n_treated
 
         return {}, weights, subclasses
 
@@ -504,6 +581,9 @@ class CEMMatcher(BaseMatcher):
                      n_total = n_treat + n_control
                      weights.loc[treated_in_group['__original_index__']] = n_total / n_treat
                      weights.loc[control_in_group['__original_index__']] = n_total / n_control
+                elif estimand == "ATC":
+                    weights.loc[control_in_group['__original_index__']] = 1.0
+                    weights.loc[treated_in_group['__original_index__']] = n_control / n_treat
 
         return matches, weights, subclasses
 
@@ -522,12 +602,14 @@ class FullMatcher(BaseMatcher):
                  min_controls_per_subclass: int = 1,
                  max_controls_per_subclass: Optional[int] = None,
                  random_state: Optional[int] = None,
-                 mahalanobis: bool = False):
+                 mahalanobis: bool = False,
+                 mahvars: Optional[List[str]] = None):
         super().__init__(ratio=1, replace=False, random_state=random_state)
         self.caliper = caliper
         self.min_controls = min_controls_per_subclass
         self.max_controls = max_controls_per_subclass
         self.mahalanobis = mahalanobis
+        self.mahvars = mahvars
 
     def match(self, treatment, distance_measure=None, covariates=None,
               estimand="ATT", exact=None, **kwargs):
@@ -581,7 +663,7 @@ class FullMatcher(BaseMatcher):
         if self.mahalanobis:
             if covariates is None:
                 raise ValueError("Covariates required for Mahalanobis matching.")
-            num_covs = covariates.select_dtypes(include=[np.number])
+            num_covs = _resolve_mahalanobis_covariates(covariates, self.mahvars)
             X_t = num_covs[treated_mask].values
             X_c = num_covs[control_mask].values
             try:
@@ -698,6 +780,10 @@ class GeneticMatcher(BaseMatcher):
         if covariates is None:
             raise ValueError("Covariates are required for Genetic Matching.")
 
+        if estimand == "ATC":
+            # The control group becomes the focal group (see NearestNeighborMatcher)
+            treatment = 1 - treatment
+
         num_covs = covariates.select_dtypes(include=[np.number])
         if num_covs.shape[1] == 0:
             raise ValueError("Genetic Matching requires at least one numeric covariate.")
@@ -713,6 +799,13 @@ class GeneticMatcher(BaseMatcher):
 
         if len(treated_indices) == 0 or len(control_indices) == 0:
             return self._build_result({}, treatment.index)
+
+        # Positional arrays of the distance measure (index labels cannot be
+        # used as positions: they differ after discard or with custom indexes)
+        dist_t_vals = dist_c_vals = None
+        if distance_measure is not None:
+            dist_t_vals = distance_measure[treated_mask].values
+            dist_c_vals = distance_measure[control_mask].values
 
         # Parse caliper
         global_caliper_threshold = None
@@ -745,9 +838,8 @@ class GeneticMatcher(BaseMatcher):
             for i in range(len(X_t_w)):
                 for j in range(min(self.ratio, dists.shape[1])):
                     # Apply caliper if needed
-                    if global_caliper_threshold is not None and distance_measure is not None:
-                        ps_diff = abs(distance_measure.iloc[treated_indices[i]] -
-                                      distance_measure.iloc[control_indices[neighbor_indices[i, j]]])
+                    if global_caliper_threshold is not None and dist_t_vals is not None:
+                        ps_diff = abs(dist_t_vals[i] - dist_c_vals[neighbor_indices[i, j]])
                         if ps_diff > global_caliper_threshold:
                             continue
                     matched_control_indices.add(neighbor_indices[i, j])
@@ -817,8 +909,13 @@ class GeneticMatcher(BaseMatcher):
         X_t_final = X_t @ W_final
         X_c_final = X_c @ W_final
 
-        k = min(len(X_c_final), self.ratio)
-        nn = NearestNeighbors(n_neighbors=max(k, 1), metric='euclidean', algorithm='auto')
+        # Without replacement (or with a caliper), the nearest candidates may
+        # be taken or invalid, so all controls must be considered
+        if self.replace and global_caliper_threshold is None:
+            k = max(min(len(X_c_final), self.ratio), 1)
+        else:
+            k = len(X_c_final)
+        nn = NearestNeighbors(n_neighbors=k, metric='euclidean', algorithm='auto')
         nn.fit(X_c_final)
         dists, neighbor_indices = nn.kneighbors(X_t_final)
 
@@ -836,9 +933,8 @@ class GeneticMatcher(BaseMatcher):
                     continue
 
                 # Apply caliper
-                if global_caliper_threshold is not None and distance_measure is not None:
-                    ps_diff = abs(distance_measure.loc[treated_indices[i]] -
-                                  distance_measure.loc[control_indices[local_pos]])
+                if global_caliper_threshold is not None and dist_t_vals is not None:
+                    ps_diff = abs(dist_t_vals[i] - dist_c_vals[local_pos])
                     if ps_diff > global_caliper_threshold:
                         continue
 
@@ -849,12 +945,7 @@ class GeneticMatcher(BaseMatcher):
             if found:
                 matches[t_idx] = found
 
-        matches_dict, weights, subclasses = self._build_result(matches, treatment.index)
-
-        if estimand == "ATT" and self.ratio > 1:
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-
-        return matches_dict, weights, subclasses
+        return self._build_result(matches, treatment.index)
 
 
 class CardinalityMatcher(BaseMatcher):

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,264 @@
+# Regression tests for logic bugs found in the 2026-06 review.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pymatchit.core import MatchIt
+
+
+@pytest.fixture
+def sim_data():
+    """Simulated data: 200 units, ~60% treated, binary 'site' variable."""
+    rng = np.random.RandomState(0)
+    n = 200
+    df = pd.DataFrame(
+        {
+            "age": rng.normal(40, 10, n),
+            "educ": rng.randint(8, 18, n),
+            "black": rng.binomial(1, 0.3, n),
+            "site": rng.randint(0, 2, n),
+        }
+    )
+    ps_true = 1 / (1 + np.exp(-(-3 + 0.05 * df.age + 0.1 * df.educ)))
+    df["treat"] = rng.binomial(1, ps_true)
+    return df
+
+
+# ==========================================
+# Crash fixes
+# ==========================================
+def test_optimal_with_tight_caliper_does_not_crash(sim_data):
+    """Calipers used to make linear_sum_assignment raise 'cost matrix is infeasible'."""
+    m = MatchIt(sim_data, method="optimal", caliper=0.001, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    # A strict caliper should drop pairs, not crash
+    m_loose = MatchIt(sim_data, method="optimal", random_state=1)
+    m_loose.fit("treat ~ age + educ + black")
+    assert len(m.matched_data) < len(m_loose.matched_data)
+
+
+def test_optimal_caliper_respected(sim_data):
+    caliper = 0.5
+    m = MatchIt(sim_data, method="optimal", caliper=caliper, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    threshold = caliper * m.distance_measure.std()
+    pairs = m.matches()
+    for row in pairs.itertuples():
+        diff = abs(
+            m.distance_measure.loc[row.treated_index]
+            - m.distance_measure.loc[row.control_index]
+        )
+        assert diff <= threshold + 1e-12
+
+
+def test_genetic_with_caliper_and_custom_index(sim_data):
+    """Genetic matching used .iloc with index labels: crashed on offset indexes."""
+    df = sim_data.copy()
+    df.index = df.index + 1000
+    m = MatchIt(
+        df, method="genetic", caliper=0.25, pop_size=10, max_generations=2, random_state=1
+    )
+    m.fit("treat ~ age + educ + black")
+    assert len(m.matched_data) > 0
+
+
+# ==========================================
+# Genetic matching without replacement
+# ==========================================
+def test_genetic_without_replacement_matches_all_possible(sim_data):
+    """Used to fetch only `ratio` neighbors, leaving most treated units unmatched."""
+    m = MatchIt(sim_data, method="genetic", pop_size=10, max_generations=2, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    n_treated = sim_data.treat.sum()
+    n_control = (sim_data.treat == 0).sum()
+    matched_treated = (m.matched_data.treat == 1).sum()
+    assert matched_treated == min(n_treated, n_control)
+
+
+# ==========================================
+# antiexact
+# ==========================================
+@pytest.mark.parametrize("method", ["nearest", "optimal"])
+def test_antiexact_enforced(sim_data, method):
+    m = MatchIt(sim_data, method=method, antiexact=["site"], random_state=1)
+    m.fit("treat ~ age + educ + black")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    for row in pairs.itertuples():
+        assert (
+            sim_data.loc[row.treated_index, "site"]
+            != sim_data.loc[row.control_index, "site"]
+        )
+
+
+def test_antiexact_with_replacement(sim_data):
+    m = MatchIt(sim_data, method="nearest", replace=True, antiexact=["site"], random_state=1)
+    m.fit("treat ~ age + educ + black")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    for row in pairs.itertuples():
+        assert (
+            sim_data.loc[row.treated_index, "site"]
+            != sim_data.loc[row.control_index, "site"]
+        )
+
+
+def test_antiexact_unsupported_method_raises(sim_data):
+    m = MatchIt(sim_data, method="cem", antiexact=["site"])
+    with pytest.raises(NotImplementedError, match="antiexact"):
+        m.fit("treat ~ age + educ")
+
+
+# ==========================================
+# mahvars
+# ==========================================
+def test_mahvars_runs_and_estimates_ps(sim_data):
+    m = MatchIt(
+        sim_data, method="nearest", mahvars=["age", "educ"], caliper=0.5, random_state=1
+    )
+    m.fit("treat ~ age + educ + black")
+    # PS must still be estimated (used for the caliper)
+    assert m.propensity_scores is not None
+    assert len(m.matched_data) > 0
+
+
+def test_mahvars_changes_matches(sim_data):
+    """Mahalanobis-on-mahvars matching must differ from plain PS matching."""
+    m_ps = MatchIt(sim_data, method="nearest", random_state=1)
+    m_ps.fit("treat ~ age + educ + black")
+    m_mah = MatchIt(sim_data, method="nearest", mahvars=["age"], random_state=1)
+    m_mah.fit("treat ~ age + educ + black")
+    pairs_ps = m_ps.matches().sort_values("treated_index").reset_index(drop=True)
+    pairs_mah = m_mah.matches().sort_values("treated_index").reset_index(drop=True)
+    assert not pairs_ps.equals(pairs_mah)
+
+
+def test_mahvars_unsupported_method_raises(sim_data):
+    m = MatchIt(sim_data, method="genetic", mahvars=["age"])
+    with pytest.raises(NotImplementedError, match="mahvars"):
+        m.fit("treat ~ age + educ")
+
+
+def test_mahvars_with_mahalanobis_distance_raises(sim_data):
+    m = MatchIt(sim_data, method="nearest", distance="mahalanobis", mahvars=["age"])
+    with pytest.raises(ValueError, match="mahvars"):
+        m.fit("treat ~ age + educ")
+
+
+# ==========================================
+# ATC estimand
+# ==========================================
+def test_atc_nearest_matches_controls_as_focal(sim_data):
+    m = MatchIt(sim_data, method="nearest", estimand="ATC", random_state=1)
+    m.fit("treat ~ age + educ + black")
+    # Keys of matched_indices must be control units
+    for key in m.matched_indices:
+        assert sim_data.loc[key, "treat"] == 0
+    pairs = m.matches()
+    assert {"treated_index", "control_index"} <= set(pairs.columns)
+    for row in pairs.itertuples():
+        assert sim_data.loc[row.control_index, "treat"] == 0
+        assert sim_data.loc[row.treated_index, "treat"] == 1
+    # Focal (control) units carry weight 1
+    md = m.matched_data
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+
+
+@pytest.mark.parametrize("method", ["exact", "cem", "subclass"])
+def test_atc_stratification_methods_produce_weights(sim_data, method):
+    """ATC used to fall through the weight branches, returning an empty matched set."""
+    df = sim_data.copy()
+    df["educ_hi"] = (df.educ > 12).astype(int)
+    formula = "treat ~ black + educ_hi" if method in ("exact", "cem") else "treat ~ age + educ"
+    m = MatchIt(df, method=method, estimand="ATC")
+    m.fit(formula)
+    md = m.matched_data
+    assert len(md) > 0
+    # Focal (control) units have weight 1, treated units fractional weights
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+    assert (md.loc[md.treat == 1, "weights"] > 0).all()
+
+
+def test_ate_with_pair_matching_raises(sim_data):
+    for method in ("nearest", "optimal", "genetic"):
+        m = MatchIt(sim_data, method=method, estimand="ATE")
+        with pytest.raises(ValueError, match="ATE"):
+            m.fit("treat ~ age + educ")
+
+
+# ==========================================
+# User-supplied distance
+# ==========================================
+def test_user_supplied_distance_used_as_is(sim_data):
+    rng = np.random.RandomState(3)
+    scores = pd.Series(rng.uniform(0, 1, len(sim_data)), index=sim_data.index)
+    m = MatchIt(sim_data, distance=scores.values, method="nearest", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, scores.values)
+
+
+def test_user_supplied_distance_nonprobability(sim_data):
+    """Generic distance scores (outside [0,1]) must not be clipped/logit-transformed."""
+    rng = np.random.RandomState(4)
+    scores = pd.Series(rng.normal(0, 5, len(sim_data)), index=sim_data.index)
+    m = MatchIt(sim_data, distance=scores.values, method="nearest", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, scores.values)
+    assert len(m.matched_data) > 0
+
+
+# ==========================================
+# Ratio weights with calipers
+# ==========================================
+def test_ratio_weights_account_for_partial_matches(sim_data):
+    """Control weights are 1/k_i per match, where k_i is the treated unit's match count."""
+    m = MatchIt(sim_data, method="nearest", ratio=2, caliper=0.2, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    pairs = m.matches(format="wide")
+    expected = {}
+    for t_idx, c_list in m.matched_indices.items():
+        k = len(c_list)
+        for c in c_list:
+            expected[c] = expected.get(c, 0.0) + 1.0 / k
+    for c_idx, w in expected.items():
+        assert m.weights.loc[c_idx] == pytest.approx(w)
+    # Treated units with only one in-caliper match exist in this configuration,
+    # and their controls must carry full weight 1
+    partial = [t for t, c in m.matched_indices.items() if len(c) == 1]
+    if partial:
+        for t in partial:
+            c = m.matched_indices[t][0]
+            assert m.weights.loc[c] == pytest.approx(1.0)
+
+
+# ==========================================
+# Caliper SD consistency with exact strata
+# ==========================================
+def test_caliper_with_exact_uses_global_sd(sim_data):
+    caliper = 0.25
+    m = MatchIt(sim_data, method="nearest", caliper=caliper, exact=["site"], random_state=1)
+    m.fit("treat ~ age + educ + black")
+    threshold = caliper * m.distance_measure.std()
+    pairs = m.matches()
+    for row in pairs.itertuples():
+        diff = abs(
+            m.distance_measure.loc[row.treated_index]
+            - m.distance_measure.loc[row.control_index]
+        )
+        assert diff <= threshold + 1e-12
+
+
+# ==========================================
+# String index support in matches()
+# ==========================================
+def test_matches_with_string_index(sim_data):
+    df = sim_data.copy()
+    # object dtype: pyarrow-backed string indexes break patsy itself (upstream issue)
+    df.index = pd.Index([f"unit_{i}" for i in range(len(df))], dtype=object)
+    m = MatchIt(df, method="nearest", random_state=1)
+    m.fit("treat ~ age + educ")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    assert pairs["treated_index"].notna().all()
+    assert pairs["treated_index"].str.startswith("unit_").all()

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -104,6 +104,23 @@ def test_antiexact_with_replacement(sim_data):
         )
 
 
+def test_antiexact_combined_with_exact(sim_data):
+    """antiexact must also be enforced inside exact-matching strata."""
+    m = MatchIt(sim_data, method="nearest", exact=["black"], antiexact=["site"], random_state=1)
+    m.fit("treat ~ age + educ")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    for row in pairs.itertuples():
+        assert (
+            sim_data.loc[row.treated_index, "black"]
+            == sim_data.loc[row.control_index, "black"]
+        )
+        assert (
+            sim_data.loc[row.treated_index, "site"]
+            != sim_data.loc[row.control_index, "site"]
+        )
+
+
 def test_antiexact_unsupported_method_raises(sim_data):
     m = MatchIt(sim_data, method="cem", antiexact=["site"])
     with pytest.raises(NotImplementedError, match="antiexact"):
@@ -132,6 +149,27 @@ def test_mahvars_changes_matches(sim_data):
     pairs_ps = m_ps.matches().sort_values("treated_index").reset_index(drop=True)
     pairs_mah = m_mah.matches().sort_values("treated_index").reset_index(drop=True)
     assert not pairs_ps.equals(pairs_mah)
+
+
+def test_mahvars_optimal_changes_matches(sim_data):
+    m_ps = MatchIt(sim_data, method="optimal", random_state=1)
+    m_ps.fit("treat ~ age + educ + black")
+    m_mah = MatchIt(sim_data, method="optimal", mahvars=["age"], random_state=1)
+    m_mah.fit("treat ~ age + educ + black")
+    assert m_mah.propensity_scores is not None
+    pairs_ps = m_ps.matches().sort_values("treated_index").reset_index(drop=True)
+    pairs_mah = m_mah.matches().sort_values("treated_index").reset_index(drop=True)
+    assert not pairs_ps.equals(pairs_mah)
+
+
+def test_mahvars_full_changes_weights(sim_data):
+    m_ps = MatchIt(sim_data, method="full", random_state=1)
+    m_ps.fit("treat ~ age + educ + black")
+    m_mah = MatchIt(sim_data, method="full", mahvars=["age"], random_state=1)
+    m_mah.fit("treat ~ age + educ + black")
+    assert m_mah.propensity_scores is not None
+    assert len(m_mah.matched_data) > 0
+    assert not m_ps.weights.equals(m_mah.weights)
 
 
 def test_mahvars_unsupported_method_raises(sim_data):
@@ -187,6 +225,21 @@ def test_ate_with_pair_matching_raises(sim_data):
             m.fit("treat ~ age + educ")
 
 
+@pytest.mark.parametrize("method", ["optimal", "genetic"])
+def test_atc_other_pair_matchers(sim_data, method):
+    """The ATC focal-group switch must also apply to optimal and genetic matching."""
+    kwargs = {"pop_size": 10, "max_generations": 2} if method == "genetic" else {}
+    m = MatchIt(sim_data, method=method, estimand="ATC", random_state=1, **kwargs)
+    m.fit("treat ~ age + educ + black")
+    assert len(m.matched_indices) > 0
+    for key, vals in m.matched_indices.items():
+        assert sim_data.loc[key, "treat"] == 0
+        for v in vals:
+            assert sim_data.loc[v, "treat"] == 1
+    md = m.matched_data
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+
+
 # ==========================================
 # User-supplied distance
 # ==========================================
@@ -223,13 +276,13 @@ def test_ratio_weights_account_for_partial_matches(sim_data):
             expected[c] = expected.get(c, 0.0) + 1.0 / k
     for c_idx, w in expected.items():
         assert m.weights.loc[c_idx] == pytest.approx(w)
-    # Treated units with only one in-caliper match exist in this configuration,
-    # and their controls must carry full weight 1
+    # This configuration produces treated units with only one in-caliper match;
+    # their controls must carry full weight 1 (not 1/ratio)
     partial = [t for t, c in m.matched_indices.items() if len(c) == 1]
-    if partial:
-        for t in partial:
-            c = m.matched_indices[t][0]
-            assert m.weights.loc[c] == pytest.approx(1.0)
+    assert len(partial) > 0
+    for t in partial:
+        c = m.matched_indices[t][0]
+        assert m.weights.loc[c] == pytest.approx(1.0)
 
 
 # ==========================================
@@ -247,6 +300,50 @@ def test_caliper_with_exact_uses_global_sd(sim_data):
             - m.distance_measure.loc[row.control_index]
         )
         assert diff <= threshold + 1e-12
+
+
+# ==========================================
+# m_order='random' must not touch the global RNG
+# ==========================================
+def test_m_order_random_does_not_reseed_global_rng(sim_data):
+    np.random.seed(123)
+    m = MatchIt(sim_data, method="nearest", m_order="random", random_state=42)
+    m.fit("treat ~ age + educ")
+    draw_after_match = np.random.rand()
+
+    np.random.seed(123)
+    draw_clean = np.random.rand()
+    assert draw_after_match == draw_clean
+
+
+def test_m_order_random_reproducible(sim_data):
+    results = []
+    for _ in range(2):
+        m = MatchIt(sim_data, method="nearest", m_order="random", random_state=7)
+        m.fit("treat ~ age + educ")
+        results.append(m.matches().sort_values("treated_index").reset_index(drop=True))
+    pd.testing.assert_frame_equal(results[0], results[1])
+
+
+# ==========================================
+# CBPS warm start
+# ==========================================
+def test_cbps_warm_start_used(sim_data, monkeypatch):
+    """beta_init was always discarded (length mismatch) and silently fell back
+    to zeros; the optimizer must now start from logistic-regression coefficients."""
+    import pymatchit.distance as dist_mod
+
+    captured = {}
+    real_minimize = dist_mod.minimize
+
+    def spy(fun, x0, **kw):
+        captured["x0"] = np.asarray(x0).copy()
+        return real_minimize(fun, x0, **kw)
+
+    monkeypatch.setattr(dist_mod, "minimize", spy)
+    ps, _ = dist_mod.estimate_distance(sim_data, "treat ~ age + educ + black", method="cbps")
+    assert captured["x0"].any(), "CBPS started from the all-zeros fallback"
+    assert ((ps > 0) & (ps < 1)).all()
 
 
 # ==========================================


### PR DESCRIPTION
## Summary

A logic review of pymatchit against R MatchIt's documented semantics found several options that were silently ignored, an estimand that produced wrong (or empty) results, and two crashes. This PR fixes all of them and adds a regression test suite. A follow-up PR (`deferred-improvements`) addresses larger design deviations.

## Silently wrong results

- **`antiexact` was a complete no-op.** It was validated and passed to the matchers, but no matcher ever read it — in testing, 44 of 78 "anti-exact" pairs shared the same value of the antiexact variable. It is now enforced for `nearest` and `optimal` matching (including inside `exact=` strata and with `replace=True`); other methods raise `NotImplementedError` instead of silently ignoring it.
- **`mahvars` was a complete no-op.** Documented as "Mahalanobis distance within PS caliper" but never used. Now implemented for `nearest`, `optimal`, and `full` matching: Mahalanobis distance on the named variables (categorical variables resolve to their design-matrix dummies), with the estimated propensity score retained for calipers, matching R's behavior. Combining `mahvars` with `distance="mahalanobis"` raises.
- **`estimand="ATC"` was effectively unimplemented.** Nearest/optimal/genetic matching silently produced ATT-style results; exact/CEM/subclass returned an **empty matched set** (their weight logic had no ATC branch). Pair matchers now switch the focal group to controls as R does — match keys are control units, and `matches()` labels its columns accordingly — and the stratification matchers gained proper ATC weights. Subclassification bin edges now come from the focal group (treated for ATT, control for ATC, everyone for ATE).
- **`estimand="ATE"` with pair matching now raises** (`nearest`/`optimal`/`genetic`), matching R's restriction, instead of silently returning ATT-style output.
- **User-supplied distance vectors were corrupted by the default link.** Pre-computed scores passed via `distance=` were clipped to (0, 1) and logit-transformed; generic (non-probability) distance scores became garbage. Supplied vectors are now used as-is, as in R.

## Crashes

- **Optimal matching crashed whenever a caliper actually bound**, with scipy's opaque `ValueError: cost matrix is infeasible` (`np.inf` cells in `linear_sum_assignment`). Forbidden pairs now receive a large finite penalty and are dropped from the solution afterwards, so calipers reduce the matched set instead of crashing.
- **Genetic matching used `.iloc` with index *labels* in its caliper check** — an `IndexError` on any non-default index, and silently wrong pairs after `discard` shifted positions. It now uses positional arrays throughout.

## Related correctness fixes

- Genetic matching without replacement fetched only `ratio` nearest neighbors, leaving matchable treated units unmatched (49 of a possible 78 in testing). It now considers all controls.
- `ratio > 1` control weights accumulate 1/k per match (k = the treated unit's actual match count) instead of a uniform ÷ratio, so weights are correct when calipers leave partial matches.
- Caliper widths with `exact=` are computed from the full-sample distance SD instead of being recomputed per stratum.
- `m_order="random"` no longer reseeds the **global** NumPy RNG.
- `matches()` no longer coerces string-labeled indexes to `<NA>`.
- The CBPS warm start was always discarded due to a double-intercept length mismatch and silently fell back to zeros; it now fits without a separate sklearn intercept.

## Test plan

- `tests/test_bugfixes.py` adds 30 regression tests covering every fix above.
- Verified the tests genuinely pin the bugs by running them against the pre-fix source: 28 of 30 fail there (the two passes are a smoke test and a determinism guard whose behavioral companions do fail).
- Full suite: 44 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
