### PR TITLE
Align link semantics, cardinality, full matching, and KS diagnostics with R MatchIt

### DIFF
--- a/src/pymatchit/core.py
+++ b/src/pymatchit/core.py
@@ -119,23 +119,17 @@ class MatchIt:
         
         # 1. Estimate Distance / Propensity Scores
         if user_supplied_distance:
-            # User supplied pre-computed propensity scores
+            # User supplied a pre-computed distance vector. Like R MatchIt, the
+            # supplied values are used as-is for matching (no link transform):
+            # they need not be probabilities, so a logit would corrupt them.
             if isinstance(self.distance, np.ndarray):
                 ps = pd.Series(self.distance, index=self.data.index)
             else:
                 ps = self.distance.copy()
                 ps.index = self.data.index
-            
+
             self.propensity_scores = ps
-            
-            # Apply link transformation
-            if self.link in ['logit', 'linear.logit']:
-                from scipy.special import logit
-                eps = 1e-9
-                clipped = np.clip(ps, eps, 1 - eps)
-                self.distance_measure = pd.Series(logit(clipped), index=self.data.index)
-            else:
-                self.distance_measure = ps.copy()
+            self.distance_measure = ps.copy()
         else:
             should_estimate_ps = (distance_method != "mahalanobis") or (self.discard != "none")
             
@@ -185,32 +179,39 @@ class MatchIt:
             print(f"Note: {self.method.capitalize()} matching does not produce pairwise matches.")
             return pd.DataFrame()
 
+        # For ATC the focal group is the control group, so the keys of
+        # matched_indices are control units and the values are treated units
+        if self.estimand == "ATC":
+            key_col, val_col, val_prefix = 'control_index', 'treated_index', 'treated'
+        else:
+            key_col, val_col, val_prefix = 'treated_index', 'control_index', 'control'
+
         if format == "long":
             rows = []
             for t_idx, c_indices in self.matched_indices.items():
                 for c_idx in c_indices:
                     rows.append({
-                        'treated_index': t_idx,
-                        'control_index': c_idx
+                        key_col: t_idx,
+                        val_col: c_idx
                     })
             df = pd.DataFrame(rows)
-            
+
         elif format == "wide":
             rows = []
             for t_idx, c_indices in self.matched_indices.items():
-                row = {'treated_index': t_idx}
+                row = {key_col: t_idx}
                 for i, c_idx in enumerate(c_indices):
-                    row[f'control_{i+1}'] = c_idx
+                    row[f'{val_prefix}_{i+1}'] = c_idx
                 rows.append(row)
             df = pd.DataFrame(rows)
-            
+
         else:
             raise ValueError("Format must be 'long' or 'wide'.")
 
-        for col in df.columns:
-            if "index" in col or "control_" in col:
+        if pd.api.types.is_integer_dtype(self.data.index):
+            for col in df.columns:
                 df[col] = pd.to_numeric(df[col], errors='coerce').astype("Int64")
-        
+
         return df
 
     def _validate_inputs(self, formula: str):
@@ -273,6 +274,31 @@ class MatchIt:
         if self.estimand not in valid_estimands:
             raise ValueError(f"Estimand must be one of {valid_estimands}, got '{self.estimand}'.")
 
+        # Pair-matching methods cannot target the ATE (same restriction as R MatchIt)
+        if self.estimand == "ATE" and self.method in ("nearest", "optimal", "genetic"):
+            raise ValueError(
+                f"estimand='ATE' is not compatible with method='{self.method}'. "
+                "Use 'full', 'subclass', 'exact', 'cem', or 'cardinality' instead."
+            )
+
+        if self.antiexact is not None and self.method not in ("nearest", "optimal"):
+            raise NotImplementedError(
+                f"antiexact is not supported for method='{self.method}'. "
+                "It is currently available for 'nearest' and 'optimal' matching."
+            )
+
+        if self.mahvars is not None:
+            if self.method not in ("nearest", "optimal", "full"):
+                raise NotImplementedError(
+                    f"mahvars is not supported for method='{self.method}'. "
+                    "It is currently available for 'nearest', 'optimal', and 'full' matching."
+                )
+            if isinstance(self.distance, str) and self.distance == "mahalanobis":
+                raise ValueError(
+                    "mahvars cannot be combined with distance='mahalanobis': mahvars already "
+                    "requests Mahalanobis matching, with the estimated distance kept for calipers."
+                )
+
         try:
             patsy.dmatrix(rhs, self.data, NA_action='raise', return_type='dataframe')
         except patsy.PatsyError as e:
@@ -322,23 +348,27 @@ class MatchIt:
 
     def _get_matcher(self) -> BaseMatcher:
         distance_method = self.distance if isinstance(self.distance, str) else "user"
-        is_mahalanobis = (distance_method == 'mahalanobis')
-        
+        # mahvars also requests Mahalanobis matching (on those variables only),
+        # with the estimated distance measure retained for calipers
+        is_mahalanobis = (distance_method == 'mahalanobis') or (self.mahvars is not None)
+
         if self.method == 'nearest':
             return NearestNeighborMatcher(
-                ratio=self.ratio, 
-                replace=self.replace, 
+                ratio=self.ratio,
+                replace=self.replace,
                 caliper=self.caliper,
                 m_order=self.m_order,
                 random_state=self.random_state,
-                mahalanobis=is_mahalanobis
+                mahalanobis=is_mahalanobis,
+                mahvars=self.mahvars
             )
         elif self.method == 'optimal':
             return OptimalMatcher(
                 ratio=self.ratio,
                 caliper=self.caliper,
                 random_state=self.random_state,
-                mahalanobis=is_mahalanobis
+                mahalanobis=is_mahalanobis,
+                mahvars=self.mahvars
             )
         elif self.method == 'exact':
             return ExactMatcher(
@@ -362,7 +392,8 @@ class MatchIt:
                 min_controls_per_subclass=self.min_controls_per_subclass,
                 max_controls_per_subclass=self.max_controls_per_subclass,
                 random_state=self.random_state,
-                mahalanobis=is_mahalanobis
+                mahalanobis=is_mahalanobis,
+                mahvars=self.mahvars
             )
         elif self.method == 'genetic':
             return GeneticMatcher(
@@ -408,8 +439,7 @@ class MatchIt:
             active_covs = X_data
             active_exact = self.data[self.exact] if self.exact else None
 
-        # Handle antiexact: filter out pairs where antiexact variables match
-        # This is done post-hoc for methods that support it
+        # Antiexact: matchers exclude pairs where any antiexact variable matches
         kwargs = {}
         if self.antiexact is not None:
             kwargs['antiexact'] = self.data[self.antiexact] if self._mask_kept is None else self.data.loc[self._mask_kept, self.antiexact]

--- a/src/pymatchit/diagnostics.py
+++ b/src/pymatchit/diagnostics.py
@@ -203,6 +203,40 @@ def compute_effective_sample_size(weights: pd.Series, treatment: pd.Series) -> D
     }
 
 
+def weighted_ks_statistic(
+    x_t: np.ndarray, w_t: np.ndarray, x_c: np.ndarray, w_c: np.ndarray
+) -> float:
+    """
+    Weighted two-sample KS statistic: the maximum vertical distance between
+    the weighted empirical CDFs of the two samples.
+    """
+    if len(x_t) == 0 or len(x_c) == 0:
+        return np.nan
+    if w_t.sum() <= 0 or w_c.sum() <= 0:
+        return np.nan
+
+    grid = np.unique(np.concatenate([x_t, x_c]))
+
+    def ecdf_at(x, w):
+        order = np.argsort(x, kind="mergesort")
+        x_sorted = x[order]
+        cum = np.cumsum(w[order]) / w.sum()
+        pos = np.searchsorted(x_sorted, grid, side="right")
+        return np.where(pos > 0, cum[np.maximum(pos - 1, 0)], 0.0)
+
+    return float(np.max(np.abs(ecdf_at(x_t, w_t) - ecdf_at(x_c, w_c))))
+
+
+def _ks_pvalue_from_ess(ks: float, ess_t: float, ess_c: float) -> float:
+    """Asymptotic two-sample KS p-value using effective sample sizes."""
+    if np.isnan(ks) or ess_t <= 0 or ess_c <= 0:
+        return np.nan
+    from scipy.stats import kstwobign
+
+    en = np.sqrt(ess_t * ess_c / (ess_t + ess_c))
+    return float(np.clip(kstwobign.sf(en * ks), 0, 1))
+
+
 def compute_ks_statistics(
     data: pd.DataFrame,
     covariates: list,
@@ -212,16 +246,19 @@ def compute_ks_statistics(
     """
     Computes the Kolmogorov-Smirnov (KS) statistic for each covariate
     between treated and control groups, before and after matching.
-    
+
     The KS statistic measures the maximum vertical distance between the
     empirical CDFs of two samples. A smaller value indicates better balance.
-    
+    The matched statistic uses the weighted ECDFs, so it is valid for
+    weighted methods (full, subclass, matching with replacement); its
+    p-value is asymptotic, based on effective sample sizes.
+
     Args:
         data: The dataset.
         covariates: List of covariate column names.
         treatment_col: Treatment indicator column name.
         weights: Matching weights.
-        
+
     Returns:
         DataFrame with KS statistics and p-values before and after matching.
     """
@@ -229,27 +266,33 @@ def compute_ks_statistics(
     treated_mask = data[treatment_col] == 1
     control_mask = data[treatment_col] == 0
     matched_mask = weights > 0
-    
+
     for cov in covariates:
         if not pd.api.types.is_numeric_dtype(data[cov]):
             continue
-            
+
         # Before matching (raw)
         x_t_raw = data.loc[treated_mask, cov].values
         x_c_raw = data.loc[control_mask, cov].values
-        
+
         ks_raw, p_raw = ks_2samp(x_t_raw, x_c_raw)
-        
-        # After matching (weighted)
-        # For KS test with weights, we resample based on weights
-        x_t_matched = data.loc[treated_mask & matched_mask, cov].values
-        x_c_matched = data.loc[control_mask & matched_mask, cov].values
-        
-        if len(x_t_matched) > 0 and len(x_c_matched) > 0:
-            ks_matched, p_matched = ks_2samp(x_t_matched, x_c_matched)
+
+        # After matching: weighted ECDFs
+        t_matched = treated_mask & matched_mask
+        c_matched = control_mask & matched_mask
+        x_t_m = data.loc[t_matched, cov].values
+        w_t_m = weights.loc[t_matched].values.astype(float)
+        x_c_m = data.loc[c_matched, cov].values
+        w_c_m = weights.loc[c_matched].values.astype(float)
+
+        ks_matched = weighted_ks_statistic(x_t_m, w_t_m, x_c_m, w_c_m)
+        if not np.isnan(ks_matched):
+            ess_t = (w_t_m.sum()) ** 2 / (w_t_m ** 2).sum()
+            ess_c = (w_c_m.sum()) ** 2 / (w_c_m ** 2).sum()
+            p_matched = _ks_pvalue_from_ess(ks_matched, ess_t, ess_c)
         else:
-            ks_matched, p_matched = np.nan, np.nan
-        
+            p_matched = np.nan
+
         rows.append({
             'Covariate': cov,
             'KS (Raw)': round(ks_raw, 4),
@@ -257,5 +300,5 @@ def compute_ks_statistics(
             'KS (Matched)': round(ks_matched, 4) if not np.isnan(ks_matched) else np.nan,
             'p-value (Matched)': round(p_matched, 4) if not np.isnan(p_matched) else np.nan,
         })
-    
+
     return pd.DataFrame(rows).set_index('Covariate')

--- a/src/pymatchit/distance.py
+++ b/src/pymatchit/distance.py
@@ -31,14 +31,17 @@ def estimate_distance(
         formula: R-style formula.
         method: 'glm', 'cbps', 'randomforest', 'decisiontree', 'neuralnet', 'gbm',
                 'adaboost', 'lasso', 'ridge', 'elasticnet'.
-        link: 'logit', 'linear.logit', 'probit' (only for GLM), or 'linear'. 
-              For ML methods, 'logit'/'linear.logit' transforms probabilities to logits.
+        link: 'logit', 'probit', 'linear.logit', or 'linear.probit'.
+              As in R MatchIt, plain links match on the predicted probability;
+              'linear.'-prefixed links match on the linear predictor (logit/probit
+              of the probability). Probit links are only available for GLM.
         distance_options: kwargs passed to the sklearn estimator (e.g. {'n_estimators': 100}).
         random_state: Seed for reproducibility.
 
     Returns:
         propensity_scores: Raw probabilities (0-1).
-        distance_measure: Value used for matching (Linear Logit or Probability).
+        distance_measure: Value used for matching (probability, or linear predictor
+                          for 'linear.'-prefixed links).
     """
     if distance_options is None:
         distance_options = {}
@@ -47,7 +50,7 @@ def estimate_distance(
     if method == "glm":
         # Define Family/Link
         family = sm.families.Binomial()
-        if link == 'probit':
+        if link in ['probit', 'linear.probit']:
             family = sm.families.Binomial(link=sm.families.links.Probit())
         elif link in ['logit', 'linear.logit']:
             family = sm.families.Binomial(link=sm.families.links.Logit())
@@ -59,9 +62,10 @@ def estimate_distance(
             raise RuntimeError(f"Failed to fit GLM Propensity Score model: {str(e)}")
 
         propensity_scores = result.fittedvalues
-        
-        # Calculate Distance Measure
-        if link in ['logit', 'linear.logit', 'probit']:
+
+        # As in R MatchIt: plain links match on the predicted probability,
+        # 'linear.'-prefixed links match on the linear predictor
+        if link in ['linear.logit', 'linear.probit']:
             distance_measure = result.predict(which="linear")
         else:
             distance_measure = propensity_scores
@@ -122,8 +126,9 @@ def estimate_distance(
         scores = model.predict_proba(X)[:, 1]
         propensity_scores = pd.Series(scores, index=data.index)
 
-        # Calculate Distance Measure (Logit transformation if requested)
-        if link in ['logit', 'linear.logit']:
+        # Plain links match on the probability; only 'linear.logit' applies
+        # the logit transform for ML methods
+        if link == 'linear.logit':
             # Clip probabilities to avoid inf/nan in logit
             eps = 1e-9
             clipped_scores = np.clip(propensity_scores, eps, 1 - eps)
@@ -225,7 +230,7 @@ def _estimate_cbps(
 
     propensity_scores = pd.Series(ps, index=data.index)
 
-    if link in ['logit', 'linear.logit']:
+    if link == 'linear.logit':
         eps = 1e-9
         clipped = np.clip(ps, eps, 1 - eps)
         distance_measure = pd.Series(logit(clipped), index=data.index)

--- a/src/pymatchit/distance.py
+++ b/src/pymatchit/distance.py
@@ -198,13 +198,14 @@ def _estimate_cbps(
         # Negative because we minimize
         return -log_lik + balance_loss
 
-    # Initialize with logistic regression coefficients
+    # Initialize with logistic regression coefficients. X_arr already contains
+    # the patsy intercept column, so no separate sklearn intercept is fit.
     try:
         from sklearn.linear_model import LogisticRegression as LR
-        init_model = LR(random_state=random_state, max_iter=1000, penalty=None, solver='lbfgs')
+        init_model = LR(random_state=random_state, max_iter=1000, penalty=None,
+                        solver='lbfgs', fit_intercept=False)
         init_model.fit(X_arr, y_arr)
-        beta_init = np.concatenate([init_model.intercept_, init_model.coef_.flatten()])
-        # Pad or trim to match X columns (patsy includes intercept)
+        beta_init = init_model.coef_.flatten()
         if len(beta_init) != p:
             beta_init = np.zeros(p)
     except Exception:

--- a/src/pymatchit/matchers.py
+++ b/src/pymatchit/matchers.py
@@ -9,6 +9,32 @@ from scipy.optimize import linear_sum_assignment
 from typing import Dict, List, Optional, Tuple, Any, Union
 from abc import ABC, abstractmethod
 
+
+def _resolve_mahalanobis_covariates(covariates: pd.DataFrame, mahvars: Optional[List[str]]) -> pd.DataFrame:
+    """
+    Selects the covariate columns used to compute the Mahalanobis distance.
+    If `mahvars` is given, maps each variable name to its design-matrix
+    column(s) (categorical variables appear as dummies like 'race[T.Hispanic]').
+    """
+    if not mahvars:
+        return covariates.select_dtypes(include=[np.number])
+    cols = []
+    for v in mahvars:
+        hits = [c for c in covariates.columns if c == v or c.startswith(f"{v}[")]
+        if not hits:
+            raise ValueError(f"mahvars variable '{v}' not found among model covariates.")
+        cols.extend(hits)
+    return covariates[cols].select_dtypes(include=[np.number])
+
+
+def _antiexact_violations(anti_t: np.ndarray, anti_c: np.ndarray) -> np.ndarray:
+    """Boolean (n_treated x n_control) matrix: True where any antiexact variable matches."""
+    violations = np.zeros((anti_t.shape[0], anti_c.shape[0]), dtype=bool)
+    for k in range(anti_t.shape[1]):
+        violations |= (anti_t[:, k:k+1] == anti_c[:, k:k+1].T)
+    return violations
+
+
 class BaseMatcher(ABC):
     """
     Abstract Base Class for all matching algorithms.
@@ -32,16 +58,21 @@ class BaseMatcher(ABC):
 
     def _build_result(self, matches: Dict[int, List[int]], all_indices: pd.Index) -> Tuple[Dict, pd.Series, pd.Series]:
         matched_treated = []
-        from collections import Counter
-        control_counts = Counter()
-        
+        # Each matched control contributes 1/k_i for every focal unit i it is
+        # matched to, where k_i is that unit's number of matches. This keeps
+        # weights correct when calipers leave some units with fewer than
+        # `ratio` matches, and reduces to use-counts for 1:1 with replacement.
+        control_weights: Dict[Any, float] = {}
+
         subclasses = pd.Series(pd.NA, index=all_indices)
         group_id = 1
 
         for t, c_list in matches.items():
             matched_treated.append(t)
-            control_counts.update(c_list)
-            
+            k = len(c_list)
+            for c in c_list:
+                control_weights[c] = control_weights.get(c, 0.0) + 1.0 / k
+
             subclasses.loc[t] = group_id
             for c in c_list:
                 if pd.isna(subclasses.loc[c]):
@@ -50,10 +81,10 @@ class BaseMatcher(ABC):
 
         weights = pd.Series(0.0, index=all_indices)
         weights.loc[matched_treated] = 1.0
-        
-        for c_idx, count in control_counts.items():
-            weights.loc[c_idx] = count 
-        
+
+        for c_idx, w in control_weights.items():
+            weights.loc[c_idx] = w
+
         return matches, weights, subclasses
 
 
@@ -62,44 +93,47 @@ class NearestNeighborMatcher(BaseMatcher):
     Implements Nearest Neighbor matching (Greedy) with Covariate-Specific Calipers.
     """
 
-    def __init__(self, ratio: int = 1, replace: bool = False, 
-                 caliper: Optional[Union[float, Dict[str, float]]] = None, 
-                 m_order: str = "largest", random_state: Optional[int] = None, mahalanobis: bool = False):
+    def __init__(self, ratio: int = 1, replace: bool = False,
+                 caliper: Optional[Union[float, Dict[str, float]]] = None,
+                 m_order: str = "largest", random_state: Optional[int] = None, mahalanobis: bool = False,
+                 mahvars: Optional[List[str]] = None):
         super().__init__(ratio=ratio, replace=replace, random_state=random_state)
         self.caliper = caliper
         self.m_order = m_order
         self.mahalanobis = mahalanobis
+        self.mahvars = mahvars
 
-    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, **kwargs):
+    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, antiexact=None, **kwargs):
+        if estimand == "ATC":
+            # The control group becomes the focal group: controls are matched
+            # to treated units (mirrors R MatchIt's focal-group switch).
+            treatment = 1 - treatment
         if exact is not None:
-            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact)
-        return self._match_global(treatment, distance_measure, covariates, estimand)
+            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact, antiexact)
+        return self._match_global(treatment, distance_measure, covariates, estimand, antiexact)
 
-    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df):
+    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df, antiexact=None):
         stratification_data = exact_df.copy()
         group_cols = list(exact_df.columns)
         grouped = stratification_data.groupby(group_cols)
         all_matches = {}
-        
+        # Caliper width is defined on the full sample's distance SD, not per stratum
+        dist_std = distance_measure.std() if distance_measure is not None else None
+
         for _, group_indices in grouped.groups.items():
             local_treat = treatment.loc[group_indices]
             if local_treat.sum() == 0 or (local_treat == 0).sum() == 0: continue
-            
+
             local_dist = distance_measure.loc[group_indices] if distance_measure is not None else None
             local_covs = covariates.loc[group_indices] if covariates is not None else None
-            
-            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand)
-            all_matches.update(matches)
-            
-        matches_dict, weights, subclasses = self._build_result(all_matches, treatment.index)
-        
-        if estimand == "ATT" and self.ratio > 1:
-            control_mask = (treatment == 0)
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-            
-        return matches_dict, weights, subclasses
+            local_anti = antiexact.loc[group_indices] if antiexact is not None else None
 
-    def _match_global(self, treatment, distance_measure, covariates, estimand):
+            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand, local_anti, dist_std=dist_std)
+            all_matches.update(matches)
+
+        return self._build_result(all_matches, treatment.index)
+
+    def _match_global(self, treatment, distance_measure, covariates, estimand, antiexact=None, dist_std=None):
         treated_mask = treatment == 1
         control_mask = treatment == 0
         treated_indices = treatment[treated_mask].index.to_numpy()
@@ -115,26 +149,29 @@ class NearestNeighborMatcher(BaseMatcher):
         elif self.caliper is not None:
             global_caliper = self.caliper
 
+        if dist_std is None and distance_measure is not None:
+            dist_std = distance_measure.std()
+
         if self.mahalanobis:
             if covariates is None: raise ValueError("Covariates required for Mahalanobis matching.")
             # For Mahalanobis, we only use numeric dummies, not the combined 'active_covs' frame
-            num_covs = covariates.select_dtypes(include=[np.number])
+            num_covs = _resolve_mahalanobis_covariates(covariates, self.mahvars)
             X_treated = num_covs[treated_mask].values
             X_control = num_covs[control_mask].values
-            
+
             try:
                 cov_matrix = num_covs.cov()
                 VI = pinv(cov_matrix.values)
             except:
                 VI = np.eye(num_covs.shape[1])
-                
+
             metric = 'mahalanobis'
             metric_params = {'VI': VI}
-            threshold = np.inf 
-            
+            threshold = np.inf
+
             if global_caliper is not None:
                 if distance_measure is None: raise ValueError("Caliper threshold requires 1D distance measure.")
-                threshold = global_caliper * distance_measure.std()
+                threshold = global_caliper * dist_std
         else:
             if distance_measure is None: raise ValueError("Distance measure required for nearest neighbor matching.")
             X_treated = distance_measure[treated_mask].values.reshape(-1, 1)
@@ -143,7 +180,7 @@ class NearestNeighborMatcher(BaseMatcher):
             metric_params = {}
             threshold = np.inf
             if global_caliper is not None:
-                threshold = global_caliper * distance_measure.std()
+                threshold = global_caliper * dist_std
 
         # Extract matrices for covariate-specific calipers
         covs_treated_caliper = None
@@ -163,66 +200,75 @@ class NearestNeighborMatcher(BaseMatcher):
             for idx, limit in enumerate(cov_calipers.values()):
                 cov_thresholds_mapped[idx] = limit
 
+        anti_treated = anti_control = None
+        if antiexact is not None:
+            anti_treated = antiexact.loc[treated_mask].values
+            anti_control = antiexact.loc[control_mask].values
+
         if self.replace:
-            matches = self._match_with_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped)
+            matches = self._match_with_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped, anti_treated, anti_control)
         else:
-            matches = self._match_without_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped)
+            matches = self._match_without_replacement(X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated_caliper, covs_control_caliper, cov_thresholds_mapped, anti_treated, anti_control)
 
-        matches_dict, weights, subclasses = self._build_result(matches, treatment.index)
-        if estimand == "ATT" and self.ratio > 1:
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-            
-        return matches_dict, weights, subclasses
+        return self._build_result(matches, treatment.index)
 
-    def _match_with_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds):
+    @staticmethod
+    def _violates_pair_constraints(i, local_pos, covs_treated, covs_control, cov_thresholds, anti_treated, anti_control):
+        if cov_thresholds:
+            for col_idx, limit in cov_thresholds.items():
+                if abs(covs_treated[i, col_idx] - covs_control[local_pos, col_idx]) > limit:
+                    return True
+        if anti_treated is not None:
+            if (anti_treated[i] == anti_control[local_pos]).any():
+                return True
+        return False
+
+    def _match_with_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds, anti_treated=None, anti_control=None):
         if len(X_control) == 0: return {}
-        
-        # If we have strict covariate calipers, we must fetch more neighbors because the closest PS match might violate the caliper
-        n_neighbors_to_fetch = len(X_control) if cov_thresholds else min(len(X_control), self.ratio)
-        
+
+        # With covariate calipers or antiexact constraints, the closest match
+        # may be invalid, so we must fetch all candidates
+        has_pair_constraints = bool(cov_thresholds) or anti_treated is not None
+        n_neighbors_to_fetch = len(X_control) if has_pair_constraints else min(len(X_control), self.ratio)
+
         nn = NearestNeighbors(n_neighbors=n_neighbors_to_fetch, metric=metric, metric_params=metric_params, algorithm='auto')
         nn.fit(X_control)
         dists, neighbor_indices = nn.kneighbors(X_treated)
-        
+
         matches = {}
         for i, t_idx in enumerate(treated_indices):
             valid_neighbors = []
             for j in range(dists.shape[1]):
                 dist = dists[i, j]
-                if dist > threshold: 
+                if dist > threshold:
                     break # Break early since distances are sorted
-                
+
                 local_pos = neighbor_indices[i, j]
-                
-                if cov_thresholds:
-                    violates_caliper = False
-                    for col_idx, limit in cov_thresholds.items():
-                        if abs(covs_treated[i, col_idx] - covs_control[local_pos, col_idx]) > limit:
-                            violates_caliper = True
-                            break
-                    if violates_caliper: continue
+
+                if self._violates_pair_constraints(i, local_pos, covs_treated, covs_control, cov_thresholds, anti_treated, anti_control):
+                    continue
 
                 valid_neighbors.append(control_indices[local_pos])
                 if len(valid_neighbors) >= self.ratio:
                     break
-                    
+
             if len(valid_neighbors) > 0:
                 matches[t_idx] = valid_neighbors
         return matches
 
-    def _match_without_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds):
+    def _match_without_replacement(self, X_treated, X_control, treated_indices, control_indices, threshold, metric, metric_params, covs_treated, covs_control, cov_thresholds, anti_treated=None, anti_control=None):
         if len(X_control) == 0: return {}
-        
+
         if self.m_order == "largest": sort_order = np.argsort(X_treated.flatten())[::-1] if X_treated.shape[1] == 1 else np.arange(len(X_treated))
         elif self.m_order == "smallest": sort_order = np.argsort(X_treated.flatten()) if X_treated.shape[1] == 1 else np.arange(len(X_treated))
-        elif self.m_order == "random": 
-            np.random.seed(self.random_state)
-            sort_order = np.random.permutation(len(X_treated))
+        elif self.m_order == "random":
+            rng = np.random.RandomState(self.random_state)
+            sort_order = rng.permutation(len(X_treated))
         else: sort_order = np.arange(len(X_treated))
 
         matches = {}
         available_mask = np.ones(len(X_control), dtype=bool)
-        
+
         n_neighbors_to_fetch = len(X_control)
         nn = NearestNeighbors(n_neighbors=n_neighbors_to_fetch, metric=metric, metric_params=metric_params)
         nn.fit(X_control)
@@ -231,24 +277,18 @@ class NearestNeighborMatcher(BaseMatcher):
         for i in sort_order:
             t_idx = treated_indices[i]
             found = []
-            
+
             for dist, local_pos in zip(dists[i], neighbors[i]):
                 if len(found) >= self.ratio: break
-                if dist > threshold: break 
+                if dist > threshold: break
                 if not available_mask[local_pos]: continue
-                
-                # Check Covariate-Specific Calipers
-                if cov_thresholds:
-                    violates_caliper = False
-                    for col_idx, limit in cov_thresholds.items():
-                        if abs(covs_treated[i, col_idx] - covs_control[local_pos, col_idx]) > limit:
-                            violates_caliper = True
-                            break
-                    if violates_caliper: continue
-                    
+
+                if self._violates_pair_constraints(i, local_pos, covs_treated, covs_control, cov_thresholds, anti_treated, anti_control):
+                    continue
+
                 found.append(control_indices[local_pos])
                 available_mask[local_pos] = False
-                    
+
             if found:
                 matches[t_idx] = found
         return matches
@@ -259,39 +299,43 @@ class OptimalMatcher(BaseMatcher):
     Implements Optimal Matching minimizing the total global distance.
     Supports Covariate-Specific Calipers.
     """
-    def __init__(self, ratio: int = 1, caliper: Optional[Union[float, Dict[str, float]]] = None, random_state: Optional[int] = None, mahalanobis: bool = False):
+    def __init__(self, ratio: int = 1, caliper: Optional[Union[float, Dict[str, float]]] = None, random_state: Optional[int] = None, mahalanobis: bool = False,
+                 mahvars: Optional[List[str]] = None):
         super().__init__(ratio=ratio, replace=False, random_state=random_state)
         self.caliper = caliper
         self.mahalanobis = mahalanobis
+        self.mahvars = mahvars
 
-    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, **kwargs):
+    def match(self, treatment, distance_measure=None, covariates=None, estimand="ATT", exact=None, antiexact=None, **kwargs):
+        if estimand == "ATC":
+            # The control group becomes the focal group (see NearestNeighborMatcher)
+            treatment = 1 - treatment
         if exact is not None:
-            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact)
-        return self._match_global(treatment, distance_measure, covariates, estimand)
+            return self._match_stratified(treatment, distance_measure, covariates, estimand, exact, antiexact)
+        return self._match_global(treatment, distance_measure, covariates, estimand, antiexact)
 
-    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df):
+    def _match_stratified(self, treatment, distance_measure, covariates, estimand, exact_df, antiexact=None):
         stratification_data = exact_df.copy()
         group_cols = list(exact_df.columns)
         grouped = stratification_data.groupby(group_cols)
         all_matches = {}
-        
+        # Caliper width is defined on the full sample's distance SD, not per stratum
+        dist_std = distance_measure.std() if distance_measure is not None else None
+
         for _, group_indices in grouped.groups.items():
             local_treat = treatment.loc[group_indices]
             if local_treat.sum() == 0 or (local_treat == 0).sum() == 0: continue
-            
+
             local_dist = distance_measure.loc[group_indices] if distance_measure is not None else None
             local_covs = covariates.loc[group_indices] if covariates is not None else None
-            
-            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand)
-            all_matches.update(matches)
-            
-        matches_dict, weights, subclasses = self._build_result(all_matches, treatment.index)
-        if estimand == "ATT" and self.ratio > 1:
-            control_mask = (treatment == 0)
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-        return matches_dict, weights, subclasses
+            local_anti = antiexact.loc[group_indices] if antiexact is not None else None
 
-    def _match_global(self, treatment, distance_measure, covariates, estimand):
+            matches, _, _ = self._match_global(local_treat, local_dist, local_covs, estimand, local_anti, dist_std=dist_std)
+            all_matches.update(matches)
+
+        return self._build_result(all_matches, treatment.index)
+
+    def _match_global(self, treatment, distance_measure, covariates, estimand, antiexact=None, dist_std=None):
         treated_mask = treatment == 1
         control_mask = treatment == 0
         treated_indices = treatment[treated_mask].index.to_numpy()
@@ -326,9 +370,18 @@ class OptimalMatcher(BaseMatcher):
             covs_c_caliper = None
             cov_limits = None
 
+        if dist_std is None and distance_measure is not None:
+            dist_std = distance_measure.std()
+
+        # Pairs violating a caliper or antiexact constraint are marked forbidden.
+        # linear_sum_assignment cannot handle np.inf when no complete feasible
+        # assignment exists, so forbidden cells get a large finite penalty and
+        # forbidden pairs are dropped from the solution afterwards.
+        forbidden = np.zeros((n_treated, n_controls), dtype=bool)
+
         if self.mahalanobis:
             if covariates is None: raise ValueError("Covariates required for Mahalanobis matching.")
-            num_covs = covariates.select_dtypes(include=[np.number])
+            num_covs = _resolve_mahalanobis_covariates(covariates, self.mahvars)
             X_t = num_covs[treated_mask].values
             X_c = num_covs[control_mask].values
             try:
@@ -336,32 +389,47 @@ class OptimalMatcher(BaseMatcher):
             except:
                 VI = np.eye(num_covs.shape[1])
             dist_matrix = cdist(X_t, X_c, metric='mahalanobis', VI=VI)
-            
+
             if global_caliper is not None:
                 if distance_measure is None: raise ValueError("Caliper requires 1D distance measure.")
                 ps_t = distance_measure[treated_mask].values.reshape(-1, 1)
                 ps_c = distance_measure[control_mask].values.reshape(-1, 1)
                 ps_dist = cdist(ps_t, ps_c, metric='euclidean')
-                threshold = global_caliper * distance_measure.std()
-                dist_matrix[ps_dist > threshold] = np.inf
+                threshold = global_caliper * dist_std
+                forbidden |= ps_dist > threshold
         else:
             if distance_measure is None: raise ValueError("Distance measure required.")
             X_t = distance_measure[treated_mask].values.reshape(-1, 1)
             X_c = distance_measure[control_mask].values.reshape(-1, 1)
             dist_matrix = cdist(X_t, X_c, metric='euclidean')
-            
-            if global_caliper is not None:
-                threshold = global_caliper * distance_measure.std()
-                dist_matrix[dist_matrix > threshold] = np.inf
 
-        # Apply covariate-specific calipers directly to dist_matrix
+            if global_caliper is not None:
+                threshold = global_caliper * dist_std
+                forbidden |= dist_matrix > threshold
+
+        # Apply covariate-specific calipers
         if cov_limits is not None:
             for col_idx, limit in enumerate(cov_limits):
                 diffs = np.abs(covs_t_caliper[:, col_idx:col_idx+1] - covs_c_caliper[:, col_idx:col_idx+1].T)
-                dist_matrix[diffs > limit] = np.inf
+                forbidden |= diffs > limit
+
+        # Apply antiexact constraints
+        if antiexact is not None:
+            anti_t = antiexact.loc[treated_mask].values
+            anti_c = antiexact.loc[control_mask].values
+            forbidden |= _antiexact_violations(anti_t, anti_c)
+
+        if forbidden.any():
+            feasible_vals = dist_matrix[~forbidden]
+            max_feasible = feasible_vals.max() if feasible_vals.size > 0 else 1.0
+            n_assignable = min(n_treated * self.ratio, n_controls)
+            penalty = (abs(max_feasible) + 1.0) * (n_assignable + 1)
+            dist_matrix = dist_matrix.copy()
+            dist_matrix[forbidden] = penalty
 
         if self.ratio > 1:
             dist_matrix = np.repeat(dist_matrix, self.ratio, axis=0)
+            forbidden = np.repeat(forbidden, self.ratio, axis=0)
             expanded_treated_indices = np.repeat(treated_indices, self.ratio)
         else:
             expanded_treated_indices = treated_indices
@@ -370,18 +438,14 @@ class OptimalMatcher(BaseMatcher):
 
         matches = {}
         for r, c in zip(row_ind, col_ind):
-            if dist_matrix[r, c] == np.inf: continue
+            if forbidden[r, c]: continue
             t_idx = expanded_treated_indices[r]
             c_idx = control_indices[c]
-            
+
             if t_idx not in matches: matches[t_idx] = []
             matches[t_idx].append(c_idx)
 
-        matches_dict, weights, subclasses = self._build_result(matches, treatment.index)
-        if estimand == "ATT" and self.ratio > 1:
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-            
-        return matches_dict, weights, subclasses
+        return self._build_result(matches, treatment.index)
 
 
 class ExactMatcher(BaseMatcher):
@@ -419,6 +483,9 @@ class ExactMatcher(BaseMatcher):
                     n_total = n_treat + n_control
                     weights.loc[treated_in_group['__original_index__']] = n_total / n_treat
                     weights.loc[control_in_group['__original_index__']] = n_total / n_control
+                elif estimand == "ATC":
+                    weights.loc[control_in_group['__original_index__']] = 1.0
+                    weights.loc[treated_in_group['__original_index__']] = n_control / n_treat
 
         return matches, weights, subclasses
 
@@ -429,8 +496,15 @@ class SubclassMatcher(BaseMatcher):
 
     def match(self, treatment, distance_measure, estimand="ATT", **kwargs):
         if distance_measure is None: raise ValueError("Propensity Scores required for Subclassification.")
-        treated_scores = distance_measure[treatment == 1]
-        _, bins = pd.qcut(treated_scores, q=self.n_subclasses, retbins=True, duplicates='drop')
+        # Bin edges come from the focal group's score distribution (R MatchIt:
+        # treated for ATT, control for ATC, everyone for ATE)
+        if estimand == "ATC":
+            ref_scores = distance_measure[treatment == 0]
+        elif estimand == "ATE":
+            ref_scores = distance_measure
+        else:
+            ref_scores = distance_measure[treatment == 1]
+        _, bins = pd.qcut(ref_scores, q=self.n_subclasses, retbins=True, duplicates='drop')
         bins[0], bins[-1] = -np.inf, np.inf
         
         subclass_labels = pd.cut(distance_measure, bins=bins, labels=False, include_lowest=True)
@@ -453,6 +527,9 @@ class SubclassMatcher(BaseMatcher):
                 n_total = n_treated + n_control
                 weights.loc[(treatment == 1) & in_bin] = n_total / n_treated
                 weights.loc[(treatment == 0) & in_bin] = n_total / n_control
+            elif estimand == "ATC":
+                weights.loc[(treatment == 0) & in_bin] = 1.0
+                weights.loc[(treatment == 1) & in_bin] = n_control / n_treated
 
         return {}, weights, subclasses
 
@@ -504,6 +581,9 @@ class CEMMatcher(BaseMatcher):
                      n_total = n_treat + n_control
                      weights.loc[treated_in_group['__original_index__']] = n_total / n_treat
                      weights.loc[control_in_group['__original_index__']] = n_total / n_control
+                elif estimand == "ATC":
+                    weights.loc[control_in_group['__original_index__']] = 1.0
+                    weights.loc[treated_in_group['__original_index__']] = n_control / n_treat
 
         return matches, weights, subclasses
 
@@ -522,12 +602,14 @@ class FullMatcher(BaseMatcher):
                  min_controls_per_subclass: int = 1,
                  max_controls_per_subclass: Optional[int] = None,
                  random_state: Optional[int] = None,
-                 mahalanobis: bool = False):
+                 mahalanobis: bool = False,
+                 mahvars: Optional[List[str]] = None):
         super().__init__(ratio=1, replace=False, random_state=random_state)
         self.caliper = caliper
         self.min_controls = min_controls_per_subclass
         self.max_controls = max_controls_per_subclass
         self.mahalanobis = mahalanobis
+        self.mahvars = mahvars
 
     def match(self, treatment, distance_measure=None, covariates=None,
               estimand="ATT", exact=None, **kwargs):
@@ -581,7 +663,7 @@ class FullMatcher(BaseMatcher):
         if self.mahalanobis:
             if covariates is None:
                 raise ValueError("Covariates required for Mahalanobis matching.")
-            num_covs = covariates.select_dtypes(include=[np.number])
+            num_covs = _resolve_mahalanobis_covariates(covariates, self.mahvars)
             X_t = num_covs[treated_mask].values
             X_c = num_covs[control_mask].values
             try:
@@ -698,6 +780,10 @@ class GeneticMatcher(BaseMatcher):
         if covariates is None:
             raise ValueError("Covariates are required for Genetic Matching.")
 
+        if estimand == "ATC":
+            # The control group becomes the focal group (see NearestNeighborMatcher)
+            treatment = 1 - treatment
+
         num_covs = covariates.select_dtypes(include=[np.number])
         if num_covs.shape[1] == 0:
             raise ValueError("Genetic Matching requires at least one numeric covariate.")
@@ -713,6 +799,13 @@ class GeneticMatcher(BaseMatcher):
 
         if len(treated_indices) == 0 or len(control_indices) == 0:
             return self._build_result({}, treatment.index)
+
+        # Positional arrays of the distance measure (index labels cannot be
+        # used as positions: they differ after discard or with custom indexes)
+        dist_t_vals = dist_c_vals = None
+        if distance_measure is not None:
+            dist_t_vals = distance_measure[treated_mask].values
+            dist_c_vals = distance_measure[control_mask].values
 
         # Parse caliper
         global_caliper_threshold = None
@@ -745,9 +838,8 @@ class GeneticMatcher(BaseMatcher):
             for i in range(len(X_t_w)):
                 for j in range(min(self.ratio, dists.shape[1])):
                     # Apply caliper if needed
-                    if global_caliper_threshold is not None and distance_measure is not None:
-                        ps_diff = abs(distance_measure.iloc[treated_indices[i]] -
-                                      distance_measure.iloc[control_indices[neighbor_indices[i, j]]])
+                    if global_caliper_threshold is not None and dist_t_vals is not None:
+                        ps_diff = abs(dist_t_vals[i] - dist_c_vals[neighbor_indices[i, j]])
                         if ps_diff > global_caliper_threshold:
                             continue
                     matched_control_indices.add(neighbor_indices[i, j])
@@ -817,8 +909,13 @@ class GeneticMatcher(BaseMatcher):
         X_t_final = X_t @ W_final
         X_c_final = X_c @ W_final
 
-        k = min(len(X_c_final), self.ratio)
-        nn = NearestNeighbors(n_neighbors=max(k, 1), metric='euclidean', algorithm='auto')
+        # Without replacement (or with a caliper), the nearest candidates may
+        # be taken or invalid, so all controls must be considered
+        if self.replace and global_caliper_threshold is None:
+            k = max(min(len(X_c_final), self.ratio), 1)
+        else:
+            k = len(X_c_final)
+        nn = NearestNeighbors(n_neighbors=k, metric='euclidean', algorithm='auto')
         nn.fit(X_c_final)
         dists, neighbor_indices = nn.kneighbors(X_t_final)
 
@@ -836,9 +933,8 @@ class GeneticMatcher(BaseMatcher):
                     continue
 
                 # Apply caliper
-                if global_caliper_threshold is not None and distance_measure is not None:
-                    ps_diff = abs(distance_measure.loc[treated_indices[i]] -
-                                  distance_measure.loc[control_indices[local_pos]])
+                if global_caliper_threshold is not None and dist_t_vals is not None:
+                    ps_diff = abs(dist_t_vals[i] - dist_c_vals[local_pos])
                     if ps_diff > global_caliper_threshold:
                         continue
 
@@ -849,12 +945,7 @@ class GeneticMatcher(BaseMatcher):
             if found:
                 matches[t_idx] = found
 
-        matches_dict, weights, subclasses = self._build_result(matches, treatment.index)
-
-        if estimand == "ATT" and self.ratio > 1:
-            weights.loc[control_mask] = weights.loc[control_mask] / self.ratio
-
-        return matches_dict, weights, subclasses
+        return self._build_result(matches, treatment.index)
 
 
 class CardinalityMatcher(BaseMatcher):

--- a/src/pymatchit/matchers.py
+++ b/src/pymatchit/matchers.py
@@ -590,12 +590,17 @@ class CEMMatcher(BaseMatcher):
 
 class FullMatcher(BaseMatcher):
     """
-    Implements Full Matching (optimal subclassification).
-    Every unit is placed into a subclass containing at least one treated and
-    one control unit. Minimizes the total within-subclass distance.
+    Implements Full Matching (subclassification with variable ratios).
+    Every matchable unit is placed into a subclass containing at least one
+    treated and one control unit.
 
-    Uses a network-flow approach via scipy's linear_sum_assignment on an
-    expanded cost matrix, then groups remaining units into their nearest subclass.
+    The algorithm is greedy but seeded by an optimal 1:1 assignment
+    (scipy's linear_sum_assignment): the majority group's remaining units
+    are then attached to the subclass of their nearest feasible opposite
+    unit. Units with no within-caliper partner are left unmatched, and
+    min/max controls per subclass are enforced. This approximates, but does
+    not guarantee, the provably optimal full matching of Hansen & Klopfer
+    (2006) used by R's optmatch.
     """
 
     def __init__(self, caliper: Optional[Union[float, Dict[str, float]]] = None,
@@ -678,7 +683,8 @@ class FullMatcher(BaseMatcher):
             X_c = distance_measure[control_mask].values.reshape(-1, 1)
             dist_matrix = cdist(X_t, X_c, metric='euclidean')
 
-        # Apply caliper
+        # Caliper feasibility: pairs outside the caliper cannot share a subclass
+        feasible = np.ones((n_t, n_c), dtype=bool)
         if self.caliper is not None:
             if isinstance(self.caliper, dict):
                 global_cal = self.caliper.get('distance', None)
@@ -690,47 +696,25 @@ class FullMatcher(BaseMatcher):
                 ps_t = distance_measure[treated_mask].values.reshape(-1, 1)
                 ps_c = distance_measure[control_mask].values.reshape(-1, 1)
                 ps_dist = cdist(ps_t, ps_c, metric='euclidean')
-                dist_matrix[ps_dist > threshold] = 1e15
+                feasible = ps_dist <= threshold
 
-        # --- Full Matching Algorithm ---
-        # Step 1: Assign each treated unit to its nearest control (seed subclasses)
-        subclass_assignments = {}  # index -> subclass_id
-        subclass_members = {}  # subclass_id -> {'treated': [], 'control': []}
+        clusters = self._build_clusters(dist_matrix, feasible, n_t, n_c)
 
-        # Each treated unit seeds a subclass
-        for i, t_idx in enumerate(treated_indices):
-            nearest_c = np.argmin(dist_matrix[i])
-            subclass_assignments[t_idx] = i
-            subclass_members[i] = {
-                'treated': [t_idx],
-                'control': [],
-                'center': dist_matrix[i, nearest_c]
-            }
-
-        # Step 2: Assign each control to the nearest treated unit's subclass
-        for j, c_idx in enumerate(control_indices):
-            distances_to_treated = dist_matrix[:, j]
-            nearest_t = np.argmin(distances_to_treated)
-            subclass_id = nearest_t  # subclass ID = treated unit's position
-            subclass_assignments[c_idx] = subclass_id
-            subclass_members[subclass_id]['control'].append(c_idx)
-
-        # Step 3: Compute weights
+        # Compute weights per subclass
         weights = pd.Series(0.0, index=treatment.index)
         subclasses = pd.Series(pd.NA, index=treatment.index)
 
-        for sc_id, members in subclass_members.items():
-            t_list = members['treated']
-            c_list = members['control']
+        for sc_num, members in enumerate(clusters, start=1):
+            t_list = [treated_indices[i] for i in members['treated']]
+            c_list = [control_indices[j] for j in members['control']]
             n_t_sub = len(t_list)
             n_c_sub = len(c_list)
 
             if n_t_sub == 0 or n_c_sub == 0:
                 continue
 
-            # Assign subclass labels (1-indexed)
             for idx in t_list + c_list:
-                subclasses.loc[idx] = sc_id + 1
+                subclasses.loc[idx] = sc_num
 
             if estimand == "ATT":
                 for idx in t_list:
@@ -750,6 +734,154 @@ class FullMatcher(BaseMatcher):
                     weights.loc[idx] = n_c_sub / n_t_sub
 
         return {}, weights, subclasses
+
+    def _build_clusters(self, dist_matrix, feasible, n_t, n_c):
+        """
+        Groups treated/control positions into subclasses.
+
+        Seeds subclasses with an optimal 1:1 assignment between the groups,
+        then attaches each remaining majority-group unit to the subclass of
+        its nearest feasible partner. Units with no feasible partner stay
+        unmatched. Returns a list of {'treated': [...], 'control': [...]}
+        with positional indices.
+        """
+        import warnings
+
+        # Work in an orientation where rows are the smaller group, so the
+        # seeding assigns one column unit to every row unit
+        transpose = n_t > n_c
+        if transpose:
+            D = dist_matrix.T
+            F = feasible.T
+        else:
+            D = dist_matrix
+            F = feasible
+        n_rows, n_cols = D.shape
+
+        if F.any():
+            penalty = (D[F].max() + 1.0) * (n_rows + 1)
+        else:
+            warnings.warn("Full matching: no pair satisfies the caliper; all units unmatched.")
+            return []
+
+        cost = np.where(F, D, penalty)
+        row_ind, col_ind = linear_sum_assignment(cost)
+
+        clusters = []          # {'rows': [...], 'cols': [...]}
+        cluster_of_row = {}
+        cluster_of_col = {}
+        deferred_rows = []
+
+        for r, c in zip(row_ind, col_ind):
+            if F[r, c]:
+                cluster_of_row[r] = len(clusters)
+                cluster_of_col[c] = len(clusters)
+                clusters.append({'rows': [r], 'cols': [c]})
+            else:
+                deferred_rows.append(r)
+
+        # In the transposed orientation rows are controls, so max_controls
+        # caps cluster row counts there; otherwise it caps column counts
+        max_rows = self.max_controls if transpose else None
+        max_cols = self.max_controls if not transpose else None
+
+        # Rows whose optimal partner was infeasible join the cluster of their
+        # nearest feasible column unit (if any); otherwise they stay unmatched
+        for r in deferred_rows:
+            feas_cols = [c for c in np.where(F[r])[0] if c in cluster_of_col]
+            if max_rows is not None:
+                feas_cols = [
+                    c for c in feas_cols
+                    if len(clusters[cluster_of_col[c]]['rows']) < max_rows
+                ]
+            if not feas_cols:
+                continue
+            nearest = min(feas_cols, key=lambda c: D[r, c])
+            cid = cluster_of_col[nearest]
+            clusters[cid]['rows'].append(r)
+            cluster_of_row[r] = cid
+
+        # Attach remaining column units to their nearest feasible row's cluster
+        remaining_cols = [c for c in range(n_cols) if c not in cluster_of_col]
+        for c in remaining_cols:
+            feas_rows = np.where(F[:, c])[0]
+            feas_rows = [r for r in feas_rows if r in cluster_of_row]
+            if not feas_rows:
+                continue
+            for r in sorted(feas_rows, key=lambda r: D[r, c]):
+                cl = clusters[cluster_of_row[r]]
+                if max_cols is not None and len(cl['cols']) >= max_cols:
+                    continue
+                cl['cols'].append(c)
+                break
+
+        if self.min_controls > 1:
+            if transpose:
+                self._merge_for_min_rows(clusters, D, warnings)
+            else:
+                self._steal_for_min_cols(clusters, D, F, warnings)
+
+        # Translate back to treated/control orientation
+        result = []
+        for cl in clusters:
+            if transpose:
+                result.append({'treated': cl['cols'], 'control': cl['rows']})
+            else:
+                result.append({'treated': cl['rows'], 'control': cl['cols']})
+        return result
+
+    def _steal_for_min_cols(self, clusters, D, F, warnings):
+        """Move controls (cols) from clusters with surplus into clusters below
+        min_controls, choosing the closest feasible donor control."""
+        for cl in clusters:
+            while len(cl['cols']) < self.min_controls:
+                donors = [
+                    (D[cl['rows'][0], c], other, c)
+                    for other in clusters
+                    if other is not cl and len(other['cols']) > self.min_controls
+                    for c in other['cols']
+                    if all(F[r, c] for r in cl['rows'])
+                ]
+                if not donors:
+                    warnings.warn(
+                        "Full matching: could not satisfy min_controls_per_subclass "
+                        "for every subclass."
+                    )
+                    return
+                _, donor, c = min(donors, key=lambda d: d[0])
+                donor['cols'].remove(c)
+                cl['cols'].append(c)
+
+    def _merge_for_min_rows(self, clusters, D, warnings):
+        """When controls are rows (more treated than controls), satisfy
+        min_controls by merging undersized clusters. Deficient clusters are
+        paired with their nearest deficient peer first, so merges don't
+        cascade into one giant subclass."""
+
+        def cross_dist(a, b):
+            # Nearest control-treated pair across the two clusters
+            return min(
+                [D[r, c] for r in a['rows'] for c in b['cols']]
+                + [D[r, c] for r in b['rows'] for c in a['cols']]
+            )
+
+        while True:
+            deficient = [cl for cl in clusters if 0 < len(cl['rows']) < self.min_controls]
+            if not deficient or len(clusters) < 2:
+                if deficient:
+                    warnings.warn(
+                        "Full matching: could not satisfy min_controls_per_subclass "
+                        "for every subclass."
+                    )
+                return
+            cl = deficient[0]
+            partners = [o for o in deficient if o is not cl] or [
+                o for o in clusters if o is not cl
+            ]
+            host = min(partners, key=lambda o: cross_dist(cl, o))
+            host['rows'].extend(cl['rows'])
+            host['cols'].extend(cl['cols'])
+            clusters.remove(cl)
 
 
 class GeneticMatcher(BaseMatcher):
@@ -955,23 +1087,106 @@ class CardinalityMatcher(BaseMatcher):
     groups satisfy user-specified balance constraints (on standardized mean
     differences).
 
-    Uses linear programming (scipy.optimize.linprog) to solve the
-    optimization problem.
+    Solves the subset-selection problem exactly as a mixed-integer linear
+    program (scipy.optimize.milp, scipy >= 1.9) using the linearized balance
+    constraints of Zubizarreta, Paredes & Rosenbaum (2014). Falls back to a
+    greedy removal heuristic — which does not guarantee maximality or that
+    the balance constraints are met — when the MILP solver is unavailable
+    or fails.
     """
 
     def __init__(self, tols: Optional[Dict[str, float]] = None,
                  std_tols: float = 0.1,
-                 random_state: Optional[int] = None):
+                 random_state: Optional[int] = None,
+                 solver_time_limit: float = 60.0):
         """
         Args:
             tols: Covariate-specific balance tolerances (absolute mean diff).
                   e.g., {'age': 2.0, 'educ': 0.5}
             std_tols: Default tolerance on standardized mean difference for
                       all covariates. Default is 0.1 (10% of a SD).
+            solver_time_limit: Time limit (seconds) for the MILP solver.
         """
         super().__init__(ratio=1, replace=False, random_state=random_state)
         self.tols = tols if tols is not None else {}
         self.std_tols = std_tols
+        self.solver_time_limit = solver_time_limit
+
+    @staticmethod
+    def _milp_select(X, target, eps, time_limit):
+        """
+        Maximum-cardinality subset of rows of X whose mean is within eps
+        (componentwise) of target. |mean(X_sel) - target| <= eps is
+        linearized as sum_j z_j * (x_jk - target_k -/+ eps_k) <=/>= 0.
+        Returns a boolean mask, or None if the solver is unavailable or
+        produced no feasible solution.
+        """
+        try:
+            from scipy.optimize import milp, LinearConstraint, Bounds
+        except ImportError:
+            return None
+
+        n, p = X.shape
+        rows, lb, ub = [], [], []
+        for k in range(p):
+            a = X[:, k] - target[k]
+            rows.append(a - eps[k]); lb.append(-np.inf); ub.append(0.0)
+            rows.append(a + eps[k]); lb.append(0.0); ub.append(np.inf)
+        rows.append(np.ones(n)); lb.append(1.0); ub.append(n)
+
+        try:
+            res = milp(
+                c=-np.ones(n),
+                constraints=LinearConstraint(np.vstack(rows), lb, ub),
+                integrality=np.ones(n),
+                bounds=Bounds(0, 1),
+                options={"time_limit": time_limit},
+            )
+        except Exception:
+            return None
+
+        if res.x is None:
+            return None
+        sel = res.x > 0.5
+        if sel.sum() == 0:
+            return None
+        # A time-limit incumbent could be infeasible; verify before accepting
+        if np.any(np.abs(X[sel].mean(axis=0) - target) > eps + 1e-8):
+            return None
+        return sel
+
+    @staticmethod
+    def _greedy_select(X, target, eps):
+        """Fallback: iteratively drop the unit most responsible for the
+        worst balance violation against the fixed target."""
+        n = X.shape[0]
+        sel = np.ones(n, dtype=bool)
+        for _ in range(n - 1):
+            means = X[sel].mean(axis=0)
+            viol = np.abs(means - target) - eps
+            if np.all(viol <= 0):
+                break
+            worst = np.argmax(viol)
+            active = np.where(sel)[0]
+            vals = X[active, worst]
+            if means[worst] > target[worst]:
+                remove = active[np.argmax(vals)]
+            else:
+                remove = active[np.argmin(vals)]
+            sel[remove] = False
+        return sel
+
+    def _select(self, X, target, eps):
+        import warnings
+        sel = self._milp_select(X, target, eps, self.solver_time_limit)
+        if sel is None:
+            warnings.warn(
+                "Cardinality matching MILP unavailable or found no feasible solution; "
+                "falling back to a greedy heuristic. The result may not be maximal and "
+                "balance constraints may be violated."
+            )
+            sel = self._greedy_select(X, target, eps)
+        return sel
 
     def match(self, treatment, distance_measure=None, covariates=None,
               estimand="ATT", exact=None, **kwargs):
@@ -1005,134 +1220,52 @@ class CardinalityMatcher(BaseMatcher):
                 # User specified absolute tolerance; convert to standardized
                 tolerances[i] = self.tols[name] / pooled_std[i]
 
-        # --- Greedy Balance-Constrained Subset Selection ---
-        # Strategy: iteratively remove the most extreme control units
-        # that contribute most to imbalance, keeping as many as possible.
+        # Tolerances in raw covariate units
+        eps_raw = tolerances * pooled_std
+
+        weights = pd.Series(0.0, index=treatment.index)
+        subclasses = pd.Series(pd.NA, index=treatment.index)
 
         if estimand == "ATT":
-            # Keep all treated, select subset of controls
-            selected_c_mask = np.ones(n_c, dtype=bool)
-
-            for iteration in range(n_c):
-                # Check current balance
-                if selected_c_mask.sum() == 0:
-                    break
-
-                X_c_sel = X_c[selected_c_mask]
-                mean_t = X_t.mean(axis=0)
-                mean_c = X_c_sel.mean(axis=0)
-                smds = np.abs(mean_t - mean_c) / pooled_std
-
-                if np.all(smds <= tolerances):
-                    break  # Balance achieved!
-
-                # Find worst covariate
-                worst_cov = np.argmax(smds - tolerances)
-
-                # Remove the control unit contributing most to imbalance
-                active_indices = np.where(selected_c_mask)[0]
-                mean_diff_sign = mean_t[worst_cov] - mean_c[worst_cov]
-
-                # If treated mean > control mean, remove the control with
-                # smallest value (pulling mean down); vice versa
-                vals = X_c[active_indices, worst_cov]
-                if mean_diff_sign < 0:
-                    # Control mean too high, remove largest
-                    remove_pos = active_indices[np.argmax(vals)]
-                else:
-                    # Control mean too low, remove smallest
-                    remove_pos = active_indices[np.argmin(vals)]
-
-                selected_c_mask[remove_pos] = False
-
-            # Build results
-            selected_controls = control_indices[selected_c_mask]
-
-            weights = pd.Series(0.0, index=treatment.index)
-            subclasses = pd.Series(pd.NA, index=treatment.index)
+            # Keep all treated; largest control subset balanced to treated means
+            sel_c = self._select(X_c, X_t.mean(axis=0), eps_raw)
+            selected_controls = control_indices[sel_c]
 
             weights.loc[treated_indices] = 1.0
-            if len(selected_controls) > 0:
-                weights.loc[selected_controls] = n_t / len(selected_controls)
+            if sel_c.sum() > 0:
+                weights.loc[selected_controls] = n_t / sel_c.sum()
 
-            # Single subclass for cardinality matching
             subclasses.loc[treated_indices] = 1
             subclasses.loc[selected_controls] = 1
 
-        elif estimand in ("ATE", "ATC"):
-            # For ATE: select subsets from both groups
-            selected_t_mask = np.ones(n_t, dtype=bool)
-            selected_c_mask = np.ones(n_c, dtype=bool)
+        elif estimand == "ATC":
+            # Mirror of ATT: keep all controls, select treated subset
+            sel_t = self._select(X_t, X_c.mean(axis=0), eps_raw)
+            selected_treated = treated_indices[sel_t]
 
-            for iteration in range(n_t + n_c):
-                if selected_t_mask.sum() == 0 or selected_c_mask.sum() == 0:
-                    break
+            weights.loc[control_indices] = 1.0
+            if sel_t.sum() > 0:
+                weights.loc[selected_treated] = n_c / sel_t.sum()
 
-                X_t_sel = X_t[selected_t_mask]
-                X_c_sel = X_c[selected_c_mask]
-                mean_t = X_t_sel.mean(axis=0)
-                mean_c = X_c_sel.mean(axis=0)
-                smds = np.abs(mean_t - mean_c) / pooled_std
+            subclasses.loc[control_indices] = 1
+            subclasses.loc[selected_treated] = 1
 
-                if np.all(smds <= tolerances):
-                    break
+        elif estimand == "ATE":
+            # Template matching: each group's subset is balanced to the
+            # full-sample means within eps/2, which guarantees the SMD
+            # between the selected groups is within the tolerance
+            overall = np.vstack([X_t, X_c]).mean(axis=0)
+            sel_t = self._select(X_t, overall, eps_raw / 2)
+            sel_c = self._select(X_c, overall, eps_raw / 2)
+            selected_treated = treated_indices[sel_t]
+            selected_controls = control_indices[sel_c]
 
-                worst_cov = np.argmax(smds - tolerances)
-                mean_diff = mean_t[worst_cov] - mean_c[worst_cov]
-
-                # Decide which group to remove from (the larger one, or the one
-                # with the extreme value)
-                all_active_t = np.where(selected_t_mask)[0]
-                all_active_c = np.where(selected_c_mask)[0]
-
-                if mean_diff > 0:
-                    # Treated mean too high: remove highest treated OR lowest control
-                    t_vals = X_t[all_active_t, worst_cov]
-                    c_vals = X_c[all_active_c, worst_cov]
-                    t_extreme_diff = t_vals.max() - mean_t[worst_cov]
-                    c_extreme_diff = mean_c[worst_cov] - c_vals.min()
-                    if t_extreme_diff >= c_extreme_diff and len(all_active_t) > 1:
-                        remove_pos = all_active_t[np.argmax(t_vals)]
-                        selected_t_mask[remove_pos] = False
-                    elif len(all_active_c) > 1:
-                        remove_pos = all_active_c[np.argmin(c_vals)]
-                        selected_c_mask[remove_pos] = False
-                    elif len(all_active_t) > 1:
-                        remove_pos = all_active_t[np.argmax(t_vals)]
-                        selected_t_mask[remove_pos] = False
-                else:
-                    # Control mean too high
-                    t_vals = X_t[all_active_t, worst_cov]
-                    c_vals = X_c[all_active_c, worst_cov]
-                    c_extreme_diff = c_vals.max() - mean_c[worst_cov]
-                    t_extreme_diff = mean_t[worst_cov] - t_vals.min()
-                    if c_extreme_diff >= t_extreme_diff and len(all_active_c) > 1:
-                        remove_pos = all_active_c[np.argmax(c_vals)]
-                        selected_c_mask[remove_pos] = False
-                    elif len(all_active_t) > 1:
-                        remove_pos = all_active_t[np.argmin(t_vals)]
-                        selected_t_mask[remove_pos] = False
-                    elif len(all_active_c) > 1:
-                        remove_pos = all_active_c[np.argmax(c_vals)]
-                        selected_c_mask[remove_pos] = False
-
-            selected_treated = treated_indices[selected_t_mask]
-            selected_controls = control_indices[selected_c_mask]
-
-            weights = pd.Series(0.0, index=treatment.index)
-            subclasses = pd.Series(pd.NA, index=treatment.index)
-
-            n_sel_t = len(selected_treated)
-            n_sel_c = len(selected_controls)
-
+            n_sel_t = int(sel_t.sum())
+            n_sel_c = int(sel_c.sum())
             if n_sel_t > 0 and n_sel_c > 0:
-                if estimand == "ATE":
-                    n_total = n_sel_t + n_sel_c
-                    weights.loc[selected_treated] = n_total / n_sel_t
-                    weights.loc[selected_controls] = n_total / n_sel_c
-                else:  # ATC
-                    weights.loc[selected_controls] = 1.0
-                    weights.loc[selected_treated] = n_sel_c / n_sel_t
+                n_total = n_sel_t + n_sel_c
+                weights.loc[selected_treated] = n_total / n_sel_t
+                weights.loc[selected_controls] = n_total / n_sel_c
 
             subclasses.loc[selected_treated] = 1
             subclasses.loc[selected_controls] = 1

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,264 @@
+# Regression tests for logic bugs found in the 2026-06 review.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pymatchit.core import MatchIt
+
+
+@pytest.fixture
+def sim_data():
+    """Simulated data: 200 units, ~60% treated, binary 'site' variable."""
+    rng = np.random.RandomState(0)
+    n = 200
+    df = pd.DataFrame(
+        {
+            "age": rng.normal(40, 10, n),
+            "educ": rng.randint(8, 18, n),
+            "black": rng.binomial(1, 0.3, n),
+            "site": rng.randint(0, 2, n),
+        }
+    )
+    ps_true = 1 / (1 + np.exp(-(-3 + 0.05 * df.age + 0.1 * df.educ)))
+    df["treat"] = rng.binomial(1, ps_true)
+    return df
+
+
+# ==========================================
+# Crash fixes
+# ==========================================
+def test_optimal_with_tight_caliper_does_not_crash(sim_data):
+    """Calipers used to make linear_sum_assignment raise 'cost matrix is infeasible'."""
+    m = MatchIt(sim_data, method="optimal", caliper=0.001, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    # A strict caliper should drop pairs, not crash
+    m_loose = MatchIt(sim_data, method="optimal", random_state=1)
+    m_loose.fit("treat ~ age + educ + black")
+    assert len(m.matched_data) < len(m_loose.matched_data)
+
+
+def test_optimal_caliper_respected(sim_data):
+    caliper = 0.5
+    m = MatchIt(sim_data, method="optimal", caliper=caliper, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    threshold = caliper * m.distance_measure.std()
+    pairs = m.matches()
+    for row in pairs.itertuples():
+        diff = abs(
+            m.distance_measure.loc[row.treated_index]
+            - m.distance_measure.loc[row.control_index]
+        )
+        assert diff <= threshold + 1e-12
+
+
+def test_genetic_with_caliper_and_custom_index(sim_data):
+    """Genetic matching used .iloc with index labels: crashed on offset indexes."""
+    df = sim_data.copy()
+    df.index = df.index + 1000
+    m = MatchIt(
+        df, method="genetic", caliper=0.25, pop_size=10, max_generations=2, random_state=1
+    )
+    m.fit("treat ~ age + educ + black")
+    assert len(m.matched_data) > 0
+
+
+# ==========================================
+# Genetic matching without replacement
+# ==========================================
+def test_genetic_without_replacement_matches_all_possible(sim_data):
+    """Used to fetch only `ratio` neighbors, leaving most treated units unmatched."""
+    m = MatchIt(sim_data, method="genetic", pop_size=10, max_generations=2, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    n_treated = sim_data.treat.sum()
+    n_control = (sim_data.treat == 0).sum()
+    matched_treated = (m.matched_data.treat == 1).sum()
+    assert matched_treated == min(n_treated, n_control)
+
+
+# ==========================================
+# antiexact
+# ==========================================
+@pytest.mark.parametrize("method", ["nearest", "optimal"])
+def test_antiexact_enforced(sim_data, method):
+    m = MatchIt(sim_data, method=method, antiexact=["site"], random_state=1)
+    m.fit("treat ~ age + educ + black")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    for row in pairs.itertuples():
+        assert (
+            sim_data.loc[row.treated_index, "site"]
+            != sim_data.loc[row.control_index, "site"]
+        )
+
+
+def test_antiexact_with_replacement(sim_data):
+    m = MatchIt(sim_data, method="nearest", replace=True, antiexact=["site"], random_state=1)
+    m.fit("treat ~ age + educ + black")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    for row in pairs.itertuples():
+        assert (
+            sim_data.loc[row.treated_index, "site"]
+            != sim_data.loc[row.control_index, "site"]
+        )
+
+
+def test_antiexact_unsupported_method_raises(sim_data):
+    m = MatchIt(sim_data, method="cem", antiexact=["site"])
+    with pytest.raises(NotImplementedError, match="antiexact"):
+        m.fit("treat ~ age + educ")
+
+
+# ==========================================
+# mahvars
+# ==========================================
+def test_mahvars_runs_and_estimates_ps(sim_data):
+    m = MatchIt(
+        sim_data, method="nearest", mahvars=["age", "educ"], caliper=0.5, random_state=1
+    )
+    m.fit("treat ~ age + educ + black")
+    # PS must still be estimated (used for the caliper)
+    assert m.propensity_scores is not None
+    assert len(m.matched_data) > 0
+
+
+def test_mahvars_changes_matches(sim_data):
+    """Mahalanobis-on-mahvars matching must differ from plain PS matching."""
+    m_ps = MatchIt(sim_data, method="nearest", random_state=1)
+    m_ps.fit("treat ~ age + educ + black")
+    m_mah = MatchIt(sim_data, method="nearest", mahvars=["age"], random_state=1)
+    m_mah.fit("treat ~ age + educ + black")
+    pairs_ps = m_ps.matches().sort_values("treated_index").reset_index(drop=True)
+    pairs_mah = m_mah.matches().sort_values("treated_index").reset_index(drop=True)
+    assert not pairs_ps.equals(pairs_mah)
+
+
+def test_mahvars_unsupported_method_raises(sim_data):
+    m = MatchIt(sim_data, method="genetic", mahvars=["age"])
+    with pytest.raises(NotImplementedError, match="mahvars"):
+        m.fit("treat ~ age + educ")
+
+
+def test_mahvars_with_mahalanobis_distance_raises(sim_data):
+    m = MatchIt(sim_data, method="nearest", distance="mahalanobis", mahvars=["age"])
+    with pytest.raises(ValueError, match="mahvars"):
+        m.fit("treat ~ age + educ")
+
+
+# ==========================================
+# ATC estimand
+# ==========================================
+def test_atc_nearest_matches_controls_as_focal(sim_data):
+    m = MatchIt(sim_data, method="nearest", estimand="ATC", random_state=1)
+    m.fit("treat ~ age + educ + black")
+    # Keys of matched_indices must be control units
+    for key in m.matched_indices:
+        assert sim_data.loc[key, "treat"] == 0
+    pairs = m.matches()
+    assert {"treated_index", "control_index"} <= set(pairs.columns)
+    for row in pairs.itertuples():
+        assert sim_data.loc[row.control_index, "treat"] == 0
+        assert sim_data.loc[row.treated_index, "treat"] == 1
+    # Focal (control) units carry weight 1
+    md = m.matched_data
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+
+
+@pytest.mark.parametrize("method", ["exact", "cem", "subclass"])
+def test_atc_stratification_methods_produce_weights(sim_data, method):
+    """ATC used to fall through the weight branches, returning an empty matched set."""
+    df = sim_data.copy()
+    df["educ_hi"] = (df.educ > 12).astype(int)
+    formula = "treat ~ black + educ_hi" if method in ("exact", "cem") else "treat ~ age + educ"
+    m = MatchIt(df, method=method, estimand="ATC")
+    m.fit(formula)
+    md = m.matched_data
+    assert len(md) > 0
+    # Focal (control) units have weight 1, treated units fractional weights
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+    assert (md.loc[md.treat == 1, "weights"] > 0).all()
+
+
+def test_ate_with_pair_matching_raises(sim_data):
+    for method in ("nearest", "optimal", "genetic"):
+        m = MatchIt(sim_data, method=method, estimand="ATE")
+        with pytest.raises(ValueError, match="ATE"):
+            m.fit("treat ~ age + educ")
+
+
+# ==========================================
+# User-supplied distance
+# ==========================================
+def test_user_supplied_distance_used_as_is(sim_data):
+    rng = np.random.RandomState(3)
+    scores = pd.Series(rng.uniform(0, 1, len(sim_data)), index=sim_data.index)
+    m = MatchIt(sim_data, distance=scores.values, method="nearest", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, scores.values)
+
+
+def test_user_supplied_distance_nonprobability(sim_data):
+    """Generic distance scores (outside [0,1]) must not be clipped/logit-transformed."""
+    rng = np.random.RandomState(4)
+    scores = pd.Series(rng.normal(0, 5, len(sim_data)), index=sim_data.index)
+    m = MatchIt(sim_data, distance=scores.values, method="nearest", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, scores.values)
+    assert len(m.matched_data) > 0
+
+
+# ==========================================
+# Ratio weights with calipers
+# ==========================================
+def test_ratio_weights_account_for_partial_matches(sim_data):
+    """Control weights are 1/k_i per match, where k_i is the treated unit's match count."""
+    m = MatchIt(sim_data, method="nearest", ratio=2, caliper=0.2, random_state=1)
+    m.fit("treat ~ age + educ + black")
+    pairs = m.matches(format="wide")
+    expected = {}
+    for t_idx, c_list in m.matched_indices.items():
+        k = len(c_list)
+        for c in c_list:
+            expected[c] = expected.get(c, 0.0) + 1.0 / k
+    for c_idx, w in expected.items():
+        assert m.weights.loc[c_idx] == pytest.approx(w)
+    # Treated units with only one in-caliper match exist in this configuration,
+    # and their controls must carry full weight 1
+    partial = [t for t, c in m.matched_indices.items() if len(c) == 1]
+    if partial:
+        for t in partial:
+            c = m.matched_indices[t][0]
+            assert m.weights.loc[c] == pytest.approx(1.0)
+
+
+# ==========================================
+# Caliper SD consistency with exact strata
+# ==========================================
+def test_caliper_with_exact_uses_global_sd(sim_data):
+    caliper = 0.25
+    m = MatchIt(sim_data, method="nearest", caliper=caliper, exact=["site"], random_state=1)
+    m.fit("treat ~ age + educ + black")
+    threshold = caliper * m.distance_measure.std()
+    pairs = m.matches()
+    for row in pairs.itertuples():
+        diff = abs(
+            m.distance_measure.loc[row.treated_index]
+            - m.distance_measure.loc[row.control_index]
+        )
+        assert diff <= threshold + 1e-12
+
+
+# ==========================================
+# String index support in matches()
+# ==========================================
+def test_matches_with_string_index(sim_data):
+    df = sim_data.copy()
+    # object dtype: pyarrow-backed string indexes break patsy itself (upstream issue)
+    df.index = pd.Index([f"unit_{i}" for i in range(len(df))], dtype=object)
+    m = MatchIt(df, method="nearest", random_state=1)
+    m.fit("treat ~ age + educ")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    assert pairs["treated_index"].notna().all()
+    assert pairs["treated_index"].str.startswith("unit_").all()

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -104,6 +104,23 @@ def test_antiexact_with_replacement(sim_data):
         )
 
 
+def test_antiexact_combined_with_exact(sim_data):
+    """antiexact must also be enforced inside exact-matching strata."""
+    m = MatchIt(sim_data, method="nearest", exact=["black"], antiexact=["site"], random_state=1)
+    m.fit("treat ~ age + educ")
+    pairs = m.matches()
+    assert len(pairs) > 0
+    for row in pairs.itertuples():
+        assert (
+            sim_data.loc[row.treated_index, "black"]
+            == sim_data.loc[row.control_index, "black"]
+        )
+        assert (
+            sim_data.loc[row.treated_index, "site"]
+            != sim_data.loc[row.control_index, "site"]
+        )
+
+
 def test_antiexact_unsupported_method_raises(sim_data):
     m = MatchIt(sim_data, method="cem", antiexact=["site"])
     with pytest.raises(NotImplementedError, match="antiexact"):
@@ -132,6 +149,27 @@ def test_mahvars_changes_matches(sim_data):
     pairs_ps = m_ps.matches().sort_values("treated_index").reset_index(drop=True)
     pairs_mah = m_mah.matches().sort_values("treated_index").reset_index(drop=True)
     assert not pairs_ps.equals(pairs_mah)
+
+
+def test_mahvars_optimal_changes_matches(sim_data):
+    m_ps = MatchIt(sim_data, method="optimal", random_state=1)
+    m_ps.fit("treat ~ age + educ + black")
+    m_mah = MatchIt(sim_data, method="optimal", mahvars=["age"], random_state=1)
+    m_mah.fit("treat ~ age + educ + black")
+    assert m_mah.propensity_scores is not None
+    pairs_ps = m_ps.matches().sort_values("treated_index").reset_index(drop=True)
+    pairs_mah = m_mah.matches().sort_values("treated_index").reset_index(drop=True)
+    assert not pairs_ps.equals(pairs_mah)
+
+
+def test_mahvars_full_changes_weights(sim_data):
+    m_ps = MatchIt(sim_data, method="full", random_state=1)
+    m_ps.fit("treat ~ age + educ + black")
+    m_mah = MatchIt(sim_data, method="full", mahvars=["age"], random_state=1)
+    m_mah.fit("treat ~ age + educ + black")
+    assert m_mah.propensity_scores is not None
+    assert len(m_mah.matched_data) > 0
+    assert not m_ps.weights.equals(m_mah.weights)
 
 
 def test_mahvars_unsupported_method_raises(sim_data):
@@ -187,6 +225,21 @@ def test_ate_with_pair_matching_raises(sim_data):
             m.fit("treat ~ age + educ")
 
 
+@pytest.mark.parametrize("method", ["optimal", "genetic"])
+def test_atc_other_pair_matchers(sim_data, method):
+    """The ATC focal-group switch must also apply to optimal and genetic matching."""
+    kwargs = {"pop_size": 10, "max_generations": 2} if method == "genetic" else {}
+    m = MatchIt(sim_data, method=method, estimand="ATC", random_state=1, **kwargs)
+    m.fit("treat ~ age + educ + black")
+    assert len(m.matched_indices) > 0
+    for key, vals in m.matched_indices.items():
+        assert sim_data.loc[key, "treat"] == 0
+        for v in vals:
+            assert sim_data.loc[v, "treat"] == 1
+    md = m.matched_data
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+
+
 # ==========================================
 # User-supplied distance
 # ==========================================
@@ -223,13 +276,13 @@ def test_ratio_weights_account_for_partial_matches(sim_data):
             expected[c] = expected.get(c, 0.0) + 1.0 / k
     for c_idx, w in expected.items():
         assert m.weights.loc[c_idx] == pytest.approx(w)
-    # Treated units with only one in-caliper match exist in this configuration,
-    # and their controls must carry full weight 1
+    # This configuration produces treated units with only one in-caliper match;
+    # their controls must carry full weight 1 (not 1/ratio)
     partial = [t for t, c in m.matched_indices.items() if len(c) == 1]
-    if partial:
-        for t in partial:
-            c = m.matched_indices[t][0]
-            assert m.weights.loc[c] == pytest.approx(1.0)
+    assert len(partial) > 0
+    for t in partial:
+        c = m.matched_indices[t][0]
+        assert m.weights.loc[c] == pytest.approx(1.0)
 
 
 # ==========================================
@@ -247,6 +300,50 @@ def test_caliper_with_exact_uses_global_sd(sim_data):
             - m.distance_measure.loc[row.control_index]
         )
         assert diff <= threshold + 1e-12
+
+
+# ==========================================
+# m_order='random' must not touch the global RNG
+# ==========================================
+def test_m_order_random_does_not_reseed_global_rng(sim_data):
+    np.random.seed(123)
+    m = MatchIt(sim_data, method="nearest", m_order="random", random_state=42)
+    m.fit("treat ~ age + educ")
+    draw_after_match = np.random.rand()
+
+    np.random.seed(123)
+    draw_clean = np.random.rand()
+    assert draw_after_match == draw_clean
+
+
+def test_m_order_random_reproducible(sim_data):
+    results = []
+    for _ in range(2):
+        m = MatchIt(sim_data, method="nearest", m_order="random", random_state=7)
+        m.fit("treat ~ age + educ")
+        results.append(m.matches().sort_values("treated_index").reset_index(drop=True))
+    pd.testing.assert_frame_equal(results[0], results[1])
+
+
+# ==========================================
+# CBPS warm start
+# ==========================================
+def test_cbps_warm_start_used(sim_data, monkeypatch):
+    """beta_init was always discarded (length mismatch) and silently fell back
+    to zeros; the optimizer must now start from logistic-regression coefficients."""
+    import pymatchit.distance as dist_mod
+
+    captured = {}
+    real_minimize = dist_mod.minimize
+
+    def spy(fun, x0, **kw):
+        captured["x0"] = np.asarray(x0).copy()
+        return real_minimize(fun, x0, **kw)
+
+    monkeypatch.setattr(dist_mod, "minimize", spy)
+    ps, _ = dist_mod.estimate_distance(sim_data, "treat ~ age + educ + black", method="cbps")
+    assert captured["x0"].any(), "CBPS started from the all-zeros fallback"
+    assert ((ps > 0) & (ps < 1)).all()
 
 
 # ==========================================

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -1,0 +1,228 @@
+# Tests for the deferred improvements: R-consistent link semantics, MILP
+# cardinality matching, structured full matching, and weighted KS statistics.
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.special import logit as logit_fn
+from scipy.stats import ks_2samp
+
+from pymatchit.core import MatchIt
+from pymatchit.diagnostics import compute_ks_statistics, weighted_ks_statistic
+
+
+@pytest.fixture
+def sim_data():
+    rng = np.random.RandomState(0)
+    n = 300
+    df = pd.DataFrame(
+        {
+            "age": rng.normal(40, 10, n),
+            "educ": rng.randint(8, 18, n),
+            "black": rng.binomial(1, 0.3, n),
+        }
+    )
+    ps_true = 1 / (1 + np.exp(-(-3 + 0.05 * df.age + 0.1 * df.educ)))
+    df["treat"] = rng.binomial(1, ps_true)  # majority treated
+    return df
+
+
+@pytest.fixture
+def sim_data_many_controls(sim_data):
+    rng = np.random.RandomState(1)
+    df = sim_data.copy()
+    df["treat"] = rng.binomial(1, 0.25, len(df))  # majority control
+    return df
+
+
+# ==========================================
+# Link semantics (R MatchIt behavior)
+# ==========================================
+def test_link_logit_matches_on_probability(sim_data):
+    m = MatchIt(sim_data, method="nearest", link="logit", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, m.propensity_scores.values)
+
+
+def test_link_linear_logit_matches_on_linear_predictor(sim_data):
+    m = MatchIt(sim_data, method="nearest", link="linear.logit", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(
+        m.distance_measure.values, logit_fn(m.propensity_scores.values), atol=1e-8
+    )
+
+
+def test_link_probit_matches_on_probability(sim_data):
+    m = MatchIt(sim_data, method="nearest", link="probit", random_state=1)
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, m.propensity_scores.values)
+    m_lin = MatchIt(sim_data, method="nearest", link="linear.probit", random_state=1)
+    m_lin.fit("treat ~ age + educ")
+    # Linear predictor differs from the probability and is unbounded
+    assert not np.allclose(m_lin.distance_measure.values, m_lin.propensity_scores.values)
+
+
+def test_link_logit_ml_method_matches_on_probability(sim_data):
+    m = MatchIt(
+        sim_data,
+        method="nearest",
+        distance="randomforest",
+        link="logit",
+        distance_options={"n_estimators": 10},
+        random_state=1,
+    )
+    m.fit("treat ~ age + educ")
+    np.testing.assert_allclose(m.distance_measure.values, m.propensity_scores.values)
+
+
+# ==========================================
+# Cardinality matching (MILP)
+# ==========================================
+def test_cardinality_att_satisfies_balance(sim_data_many_controls):
+    df = sim_data_many_controls
+    tol = 0.05
+    m = MatchIt(df, method="cardinality", std_tols=tol)
+    m.fit("treat ~ age + educ + black")
+
+    covs = ["age", "educ", "black"]
+    t_mask = df.treat == 1
+    c_sel = (df.treat == 0) & (m.weights > 0)
+    pooled = np.sqrt((df.loc[t_mask, covs].var() + df.loc[~t_mask, covs].var()) / 2)
+    smd = (df.loc[t_mask, covs].mean() - df.loc[c_sel, covs].mean()).abs() / pooled
+    assert (smd <= tol + 1e-6).all()
+    # All treated retained with weight 1
+    assert (m.weights[t_mask] == 1.0).all()
+
+
+def test_cardinality_milp_at_least_as_large_as_greedy(sim_data_many_controls):
+    from pymatchit.matchers import CardinalityMatcher
+
+    df = sim_data_many_controls
+    covs = ["age", "educ", "black"]
+    X_t = df.loc[df.treat == 1, covs].values
+    X_c = df.loc[df.treat == 0, covs].values
+    pooled = np.sqrt((X_t.var(axis=0) + X_c.var(axis=0)) / 2)
+    eps = 0.05 * pooled
+    target = X_t.mean(axis=0)
+
+    milp_sel = CardinalityMatcher._milp_select(X_c, target, eps, time_limit=60.0)
+    greedy_sel = CardinalityMatcher._greedy_select(X_c, target, eps)
+    assert milp_sel is not None
+    assert milp_sel.sum() >= greedy_sel.sum()
+
+
+def test_cardinality_atc_mirrors_att(sim_data):
+    m = MatchIt(sim_data, method="cardinality", std_tols=0.05, estimand="ATC")
+    m.fit("treat ~ age + educ + black")
+    md = m.matched_data
+    # All controls retained with weight 1; a treated subset selected
+    assert (md.loc[md.treat == 0, "weights"] == 1.0).all()
+    assert 0 < (md.treat == 1).sum() <= sim_data.treat.sum()
+
+
+def test_cardinality_ate_balances_both_groups(sim_data):
+    tol = 0.1
+    m = MatchIt(sim_data, method="cardinality", std_tols=tol, estimand="ATE")
+    m.fit("treat ~ age + educ + black")
+
+    df = sim_data
+    covs = ["age", "educ", "black"]
+    sel_t = (df.treat == 1) & (m.weights > 0)
+    sel_c = (df.treat == 0) & (m.weights > 0)
+    assert sel_t.sum() > 0 and sel_c.sum() > 0
+    pooled = np.sqrt(
+        (df.loc[df.treat == 1, covs].var() + df.loc[df.treat == 0, covs].var()) / 2
+    )
+    smd = (df.loc[sel_t, covs].mean() - df.loc[sel_c, covs].mean()).abs() / pooled
+    assert (smd <= tol + 1e-6).all()
+
+
+# ==========================================
+# Full matching
+# ==========================================
+def test_full_matching_caliper_respected(sim_data):
+    caliper = 0.1
+    m = MatchIt(sim_data, method="full", caliper=caliper)
+    m.fit("treat ~ age + educ + black")
+    threshold = caliper * m.distance_measure.std()
+    md = m.matched_data
+    for _, grp in md.groupby("subclass"):
+        d = m.distance_measure.loc[grp.index]
+        t_d = d[grp.treat == 1]
+        c_d = d[grp.treat == 0]
+        for tv in t_d:
+            for cv in c_d:
+                assert abs(tv - cv) <= threshold + 1e-9
+
+
+@pytest.mark.parametrize("fixture", ["sim_data", "sim_data_many_controls"])
+def test_full_matching_max_controls(fixture, request):
+    df = request.getfixturevalue(fixture)
+    m = MatchIt(df, method="full", max_controls_per_subclass=3)
+    m.fit("treat ~ age + educ + black")
+    md = m.matched_data
+    sizes = md[md.treat == 0].groupby("subclass").size()
+    assert sizes.max() <= 3
+
+
+@pytest.mark.parametrize("fixture", ["sim_data", "sim_data_many_controls"])
+def test_full_matching_min_controls(fixture, request):
+    df = request.getfixturevalue(fixture)
+    m = MatchIt(df, method="full", min_controls_per_subclass=2)
+    m.fit("treat ~ age + educ + black")
+    md = m.matched_data
+    sizes = md[md.treat == 0].groupby("subclass").size()
+    assert sizes.min() >= 2
+
+
+def test_full_matching_no_caliper_matches_everyone(sim_data):
+    m = MatchIt(sim_data, method="full")
+    m.fit("treat ~ age + educ + black")
+    assert (m.weights > 0).all()
+
+
+def test_full_matching_subclasses_have_both_groups(sim_data):
+    m = MatchIt(sim_data, method="full", caliper=0.2)
+    m.fit("treat ~ age + educ + black")
+    md = m.matched_data
+    for _, grp in md.groupby("subclass"):
+        assert (grp.treat == 1).any()
+        assert (grp.treat == 0).any()
+
+
+# ==========================================
+# Weighted KS statistics
+# ==========================================
+def test_weighted_ks_uniform_weights_equals_ks_2samp():
+    rng = np.random.RandomState(2)
+    x1 = rng.normal(0, 1, 100)
+    x2 = rng.normal(0.5, 1, 80)
+    wks = weighted_ks_statistic(x1, np.ones(100), x2, np.ones(80))
+    assert wks == pytest.approx(ks_2samp(x1, x2).statistic)
+
+
+def test_weighted_ks_responds_to_weights():
+    # Control sample = treated sample plus outliers; downweighting the
+    # outliers must shrink the weighted KS toward zero
+    x_t = np.array([1.0, 2.0, 3.0, 4.0])
+    w_t = np.ones(4)
+    x_c = np.array([1.0, 2.0, 3.0, 4.0, 100.0, 100.0])
+    w_unif = np.ones(6)
+    w_down = np.array([1.0, 1.0, 1.0, 1.0, 1e-9, 1e-9])
+    ks_unif = weighted_ks_statistic(x_t, w_t, x_c, w_unif)
+    ks_down = weighted_ks_statistic(x_t, w_t, x_c, w_down)
+    assert ks_down < ks_unif
+    assert ks_down == pytest.approx(0.0, abs=1e-6)
+
+
+def test_compute_ks_statistics_uses_weights(sim_data):
+    m = MatchIt(sim_data, method="full")
+    m.fit("treat ~ age + educ + black")
+
+    ks_weighted = compute_ks_statistics(m.data, ["age", "educ"], "treat", m.weights)
+    # Compare with deliberately unweighted (all weight-1 among matched)
+    flat = (m.weights > 0).astype(float)
+    ks_flat = compute_ks_statistics(m.data, ["age", "educ"], "treat", flat)
+    assert not ks_weighted["KS (Matched)"].equals(ks_flat["KS (Matched)"])
+    assert ks_weighted["KS (Matched)"].notna().all()
+    assert ks_weighted["p-value (Matched)"].notna().all()


### PR DESCRIPTION
> **Stacked on #12** — this branch builds on `worktree-bugfixes`, so the diff includes #12's commits until it merges. The changes new to this PR are in commit d85f3e6 only. Please merge #12 first.

## Summary

Follow-up to the bug-fix PR, addressing four larger design deviations from R MatchIt that were deferred because they change behavior or required algorithmic work.

## 1. Link semantics now follow R (⚠️ behavior change)

Previously `link="logit"`, `"linear.logit"`, **and** `"probit"` all matched on the *linear predictor*. In R MatchIt, plain links (`logit`, `probit`) match on the **predicted probability**, and only `linear.`-prefixed links use the linear predictor. pymatchit now does the same, for GLM, the sklearn-based methods, and CBPS; `linear.probit` is newly supported.

This matters in practice because calipers are specified in SDs of the distance measure — under the old behavior, `caliper=0.2` here and `caliper=0.2` in R meant different widths. **Anyone relying on the old default (matching on the logit) should switch to `link="linear.logit"`.**

## 2. Cardinality matching is now an exact MILP

The previous implementation was a greedy outlier-removal heuristic, despite its docstring claiming linear programming. It now solves the subset-selection problem exactly via `scipy.optimize.milp` (HiGHS), using the linearized balance constraints of Zubizarreta, Paredes & Rosenbaum (2014):

- **ATT:** keep all treated; the maximum-cardinality control subset whose means are within tolerance of the treated means.
- **ATC:** the mirror — keep all controls, select treated (previously ATC incorrectly selected from both groups).
- **ATE:** each group's subset balanced to the full-sample means within ε/2, which guarantees the between-group SMD tolerance.

The greedy heuristic remains as an explicit fallback — with a warning — when the solver is unavailable (scipy < 1.9), infeasible, or times out (`solver_time_limit`, default 60 s). Solutions are verified against the constraints before being accepted. Solves the lalonde dataset in ~0.1 s.

## 3. Full matching is now structured

The old "full matching" assigned every control to its nearest treated unit: no optimization, calipers couldn't exclude anyone, and `min_controls_per_subclass` / `max_controls_per_subclass` were ignored entirely. The new algorithm:

- seeds subclasses with an **optimal 1:1 assignment** (`linear_sum_assignment`) between the groups;
- attaches each remaining majority-group unit to its nearest feasible partner's subclass;
- treats calipers as hard feasibility constraints — units with no within-caliper partner are left unmatched;
- enforces `max_controls_per_subclass` during attachment and `min_controls_per_subclass` afterwards (by stealing controls from subclasses with surplus, or pairwise cluster merging when treated outnumber controls), in **both** orientations (n_t ≶ n_c).

The docstring is explicit that this is a greedy approximation of optimal full matching (Hansen & Klopfer 2006), not optmatch parity. On lalonde it matches all 614 units with max |SMD| ≈ 0.09.

## 4. Weighted KS statistics

`compute_ks_statistics` claimed to account for matching weights but ran a plain `ks_2samp` on units with weight > 0 — wrong for full matching, subclassification, and matching with replacement, where the weighted distributions are the whole point. The matched-sample statistic now uses **weighted ECDFs** (exactly equal to `ks_2samp` under uniform weights), with asymptotic p-values based on effective sample sizes.

## Test plan

- `tests/test_improvements.py` adds 18 tests: link semantics across GLM/ML estimators, MILP balance-constraint satisfaction and superiority over greedy, ATC/ATE cardinality formulations, full-matching caliper/min/max enforcement in both orientations, and weighted-KS properties.
- Full suite: 62 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
